### PR TITLE
feat: Spotify BYOA — replace shared OAuth with per-user PKCE

### DIFF
--- a/backend/drizzle/0004_conscious_killraven.sql
+++ b/backend/drizzle/0004_conscious_killraven.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "oauth_accounts" ADD COLUMN "provider_client_id" text;--> statement-breakpoint
+ALTER TABLE "oauth_states" ADD COLUMN "client_id" text;

--- a/backend/drizzle/meta/0004_snapshot.json
+++ b/backend/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,523 @@
+{
+  "id": "bcae6a60-401b-4b05-9744-f33251fb79e7",
+  "prevId": "ed2499e1-fbdb-4847-9c9b-ed6561266e3c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_unique": {
+          "name": "email_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "provider_client_id": {
+          "name": "provider_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_provider_user_idx": {
+          "name": "oauth_accounts_provider_user_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_states_state_unique": {
+          "name": "oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_sessions": {
+      "name": "refresh_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_lookup": {
+          "name": "token_lookup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_id": {
+          "name": "rotated_from_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "inet",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renewal_count": {
+          "name": "renewal_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_sessions_token_lookup_idx": {
+          "name": "refresh_sessions_token_lookup_idx",
+          "columns": [
+            {
+              "expression": "token_lookup",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_sessions_user_id_users_id_fk": {
+          "name": "refresh_sessions_user_id_users_id_fk",
+          "tableFrom": "refresh_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776089357524,
       "tag": "0003_strange_gladiator",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776242620918,
+      "tag": "0004_conscious_killraven",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/controllers/oauth-spotify.controller.ts
+++ b/backend/src/controllers/oauth-spotify.controller.ts
@@ -9,6 +9,7 @@ const exchangeSchema = z.object({
   code: z.string(),
   state: z.string(),
   redirectUri: z.string().url(),
+  codeVerifier: z.string().optional(),
 });
 
 async function handleSpotifyCodeExchange(
@@ -16,8 +17,10 @@ async function handleSpotifyCodeExchange(
   code: string,
   redirectUri: string,
   reply: FastifyReply,
+  codeVerifier?: string,
+  pkceClientId?: string,
 ): Promise<void> {
-  const exchangeResult = await oauthService.exchangeSpotifyCode(code, redirectUri);
+  const exchangeResult = await oauthService.exchangeSpotifyCode(code, redirectUri, codeVerifier, pkceClientId);
 
   if (!exchangeResult.ok) {
     const status = exchangeResult.error === 'USERINFO_FAILED' ? 500 : 400;
@@ -49,40 +52,47 @@ async function handleSpotifyCodeExchange(
     expiresIn: expires_in,
     scope,
     providerUserId,
+    ...(pkceClientId ? { providerClientId: pkceClientId } : {}),
   });
 
   void reply.send({ status: 'linked' });
 }
 
 export async function startSpotifyOAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const { redirectUri } = req.query as { redirectUri?: string };
-  const effectiveUri = redirectUri ?? config.SPOTIFY_REDIRECT_URI ?? '';
+  const query = req.query as { redirectUri?: string };
+  const body = (req.body as { clientId?: string; codeChallenge?: string; codeChallengeMethod?: string; redirectUri?: string } | null) ?? {};
+
+  const effectiveUri = body.redirectUri ?? query.redirectUri ?? config.SPOTIFY_REDIRECT_URI ?? '';
+  const pkceClientId = body.clientId;
+  const codeChallenge = body.codeChallenge;
+  const codeChallengeMethod = body.codeChallengeMethod;
 
   if (!effectiveUri) {
     void reply.status(500).send({ error: 'No redirect URI configured' });
     return;
   }
 
-  // Validate redirect URI before creating state (fail fast — avoids orphaned state rows)
-  if (!isAllowedRedirectUri(effectiveUri, config.SPOTIFY_REDIRECT_URI)) {
+  // For PKCE (BYOA) flows, the redirect URI is the user's own extension URL — skip shared-URI validation.
+  // For legacy shared-app flows, validate against the configured server redirect URI.
+  if (!pkceClientId && !isAllowedRedirectUri(effectiveUri, config.SPOTIFY_REDIRECT_URI)) {
     void reply.status(400).send({ error: 'Redirect URI not allowed', message: 'This extension ID is not registered for Spotify. Contact support.' });
     return;
   }
 
-  const state = await oauthService.createOAuthState('spotify', 'link', req.user.sub);
+  const state = await oauthService.createOAuthState('spotify', 'link', req.user.sub, pkceClientId);
 
-  // Only force the account-chooser dialog when the user has no existing Spotify
-  // connection. This prevents silent reuse of another browser user's cached
-  // Spotify session. Users who already have a row (re-linking) skip the dialog.
   const hasExisting = await oauthService.hasOAuthAccount(req.user.sub, 'spotify');
 
+  const clientIdToUse = pkceClientId ?? config.SPOTIFY_CLIENT_ID ?? '';
+
   const params = new URLSearchParams({
-    client_id: config.SPOTIFY_CLIENT_ID ?? '',
+    client_id: clientIdToUse,
     redirect_uri: effectiveUri,
     response_type: 'code',
     scope: SPOTIFY_SCOPES,
     state,
     ...(hasExisting ? {} : { show_dialog: 'true' }),
+    ...(codeChallenge ? { code_challenge: codeChallenge, code_challenge_method: codeChallengeMethod ?? 'S256' } : {}),
   });
 
   void reply.send({ authUrl: `${SPOTIFY_AUTH_URL}?${params}` });
@@ -95,7 +105,9 @@ export async function exchangeSpotifyOAuthController(req: FastifyRequest, reply:
     return;
   }
 
-  if (!isAllowedRedirectUri(parsed.data.redirectUri, config.SPOTIFY_REDIRECT_URI)) {
+  // For PKCE (BYOA) flows, the redirect URI is the user's own extension URL — skip shared-URI validation.
+  const isPkce = parsed.data.codeVerifier !== undefined;
+  if (!isPkce && !isAllowedRedirectUri(parsed.data.redirectUri, config.SPOTIFY_REDIRECT_URI)) {
     void reply.status(400).send({ error: 'Redirect URI not allowed' });
     return;
   }
@@ -106,7 +118,8 @@ export async function exchangeSpotifyOAuthController(req: FastifyRequest, reply:
     return;
   }
 
-  await handleSpotifyCodeExchange(stateResult.data.userId, parsed.data.code, parsed.data.redirectUri, reply);
+  const pkceClientId = stateResult.data.clientId ?? undefined;
+  await handleSpotifyCodeExchange(stateResult.data.userId, parsed.data.code, parsed.data.redirectUri, reply, parsed.data.codeVerifier, pkceClientId);
 }
 
 export async function callbackSpotifyOAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -60,6 +60,8 @@ export const oauthAccounts = pgTable(
     refreshTokenEnc: text('refresh_token_enc'),
     tokenExpiresAt: timestamp('token_expires_at', { withTimezone: true }),
     scopes: text('scopes').array().notNull().default([]),
+    /** For PKCE (BYOA) Spotify connections — the user's own Spotify app client_id. Null for legacy shared-app connections. */
+    providerClientId: text('provider_client_id'),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [uniqueIndex('oauth_accounts_provider_user_idx').on(table.provider, table.providerUserId)],
@@ -74,6 +76,8 @@ export const oauthStates = pgTable('oauth_states', {
   provider: text('provider').notNull(),
   purpose: text('purpose').notNull(), // 'login' | 'link'
   used: boolean('used').notNull().default(false),
+  /** For PKCE (BYOA) Spotify flows — the user's own Spotify app client_id. Null for legacy flows. */
+  clientId: text('client_id'),
   expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });

--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -20,10 +20,11 @@ export async function createOAuthState(
   provider: OAuthProvider,
   purpose: OAuthPurpose,
   userId?: string,
+  clientId?: string,
 ): Promise<string> {
   const state = crypto.randomBytes(24).toString('base64url');
   const expiresAt = new Date(Date.now() + OAUTH_STATE_TTL_MS);
-  await db.insert(oauthStates).values({ state, provider, purpose, userId: userId ?? null, expiresAt });
+  await db.insert(oauthStates).values({ state, provider, purpose, userId: userId ?? null, clientId: clientId ?? null, expiresAt });
   return state;
 }
 
@@ -55,6 +56,7 @@ export async function verifyAndConsumeOAuthState(
       userId: row.userId,
       provider: row.provider as OAuthProvider,
       purpose: row.purpose,
+      clientId: row.clientId ?? null,
     },
   };
 }
@@ -71,10 +73,11 @@ export async function storeOAuthTokens(
   const refreshTokenEnc = tokens.refreshToken ? await encryptToken(tokens.refreshToken) : null;
   const tokenExpiresAt = new Date(Date.now() + tokens.expiresIn * 1000);
   const scopes = tokens.scope?.split(' ') ?? [];
+  const providerClientId = tokens.providerClientId ?? null;
 
   await db
     .insert(oauthAccounts)
-    .values({ userId, provider, providerUserId: tokens.providerUserId, accessTokenEnc, refreshTokenEnc, tokenExpiresAt, scopes })
+    .values({ userId, provider, providerUserId: tokens.providerUserId, accessTokenEnc, refreshTokenEnc, tokenExpiresAt, scopes, providerClientId })
     .onConflictDoUpdate({
       target: [oauthAccounts.provider, oauthAccounts.providerUserId],
       set: {
@@ -83,6 +86,7 @@ export async function storeOAuthTokens(
         ...(refreshTokenEnc ? { refreshTokenEnc } : {}),
         tokenExpiresAt,
         scopes,
+        providerClientId,
         updatedAt: new Date(),
       },
     });
@@ -192,13 +196,25 @@ function spotifyBasicAuth(): string {
 export async function exchangeSpotifyCode(
   code: string,
   redirectUri: string,
+  codeVerifier?: string,
+  pkceClientId?: string,
 ): Promise<Result<SpotifyTokenResponse & { providerUserId: string }, OAuthError>> {
   let tokenRes: Response;
   try {
+    const isPkce = codeVerifier !== undefined && pkceClientId !== undefined;
+    const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded' };
+    if (!isPkce) headers['Authorization'] = spotifyBasicAuth();
+
+    const bodyParams: Record<string, string> = { code, redirect_uri: redirectUri, grant_type: 'authorization_code' };
+    if (isPkce) {
+      bodyParams['client_id'] = pkceClientId!;
+      bodyParams['code_verifier'] = codeVerifier!;
+    }
+
     tokenRes = await fetch(SPOTIFY_TOKEN_URL, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/x-www-form-urlencoded', Authorization: spotifyBasicAuth() },
-      body: new URLSearchParams({ code, redirect_uri: redirectUri, grant_type: 'authorization_code' }),
+      headers,
+      body: new URLSearchParams(bodyParams),
     });
   } catch {
     return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };

--- a/backend/src/services/spotify.service.ts
+++ b/backend/src/services/spotify.service.ts
@@ -85,6 +85,12 @@ async function getSpotifyToken(userId: string): Promise<string | null> {
     .limit(1);
 
   if (!account) return null;
+
+  // PKCE (BYOA) mode: use the user's own client_id in the token body — no shared Authorization header.
+  // Legacy mode: use the shared app's Basic auth header.
+  if (account.providerClientId) {
+    return getValidAccessToken(account, { tokenUrl: SPOTIFY_TOKEN_URL, pkceClientId: account.providerClientId, extraBody: {} });
+  }
   return getValidAccessToken(account, { tokenUrl: SPOTIFY_TOKEN_URL, authHeader: spotifyBasicAuth(), extraBody: {} });
 }
 

--- a/backend/src/services/token-refresh.service.ts
+++ b/backend/src/services/token-refresh.service.ts
@@ -10,8 +10,10 @@ export interface TokenRefreshConfig {
   tokenUrl: string;
   /** Additional body fields merged alongside grant_type + refresh_token. */
   extraBody: Record<string, string>;
-  /** Optional Authorization header (e.g. Basic auth for Spotify). */
+  /** Optional Authorization header (e.g. Basic auth for Spotify legacy shared-app). */
   authHeader?: string;
+  /** For PKCE (BYOA) Spotify connections — the user's own Spotify app client_id. When set, omits Authorization header and sends client_id in body instead. */
+  pkceClientId?: string;
 }
 
 /**
@@ -33,7 +35,11 @@ export async function getValidAccessToken(
   const refreshToken = await decryptToken(account.refreshTokenEnc);
 
   const headers: Record<string, string> = { 'Content-Type': 'application/x-www-form-urlencoded' };
-  if (refreshConfig.authHeader) headers['Authorization'] = refreshConfig.authHeader;
+  if (refreshConfig.pkceClientId) {
+    // PKCE (BYOA) mode: no Authorization header; client_id goes in body
+  } else if (refreshConfig.authHeader) {
+    headers['Authorization'] = refreshConfig.authHeader;
+  }
 
   const res = await fetch(refreshConfig.tokenUrl, {
     method: 'POST',
@@ -41,6 +47,7 @@ export async function getValidAccessToken(
     body: new URLSearchParams({
       grant_type: 'refresh_token',
       refresh_token: refreshToken,
+      ...(refreshConfig.pkceClientId ? { client_id: refreshConfig.pkceClientId } : {}),
       ...refreshConfig.extraBody,
     }),
   });

--- a/backend/src/types/oauth.types.ts
+++ b/backend/src/types/oauth.types.ts
@@ -19,6 +19,8 @@ export interface OAuthStateRecord {
   userId: string | null;
   provider: OAuthProvider;
   purpose: OAuthPurpose;
+  /** For PKCE (BYOA) Spotify flows — the user's own Spotify app client_id. Null for legacy flows. */
+  clientId: string | null;
 }
 
 /** Decrypted OAuth tokens ready to store in the DB. */
@@ -28,4 +30,6 @@ export interface OAuthTokenSet {
   expiresIn: number;
   scope?: string;
   providerUserId: string;
+  /** For PKCE (BYOA) Spotify connections — the user's own Spotify app client_id. */
+  providerClientId?: string;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -807,12 +807,6 @@
       color: #fbbf24;
     }
 
-    .feature-badge.limited {
-      background: rgba(251,191,36,0.1);
-      border: 1px solid rgba(251,191,36,0.28);
-      color: #fbbf24;
-    }
-
     .wn-text {
       font-size: 0.9rem;
       color: var(--muted);
@@ -1323,8 +1317,8 @@
       </div>
       <div class="feature-card">
         <span class="feature-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg></span>
-        <h3>Spotify <span class="feature-badge limited">Limited</span></h3>
-        <p>See what is playing right now directly on your dashboard. Currently invite-only while we await Spotify's extended API approval — open to everyone once granted.</p>
+        <h3>Spotify</h3>
+        <p>Connect your own free Spotify Developer app (~2 min setup at developer.spotify.com). See what's playing right now, control playback, and view your top tracks.</p>
       </div>
       <div class="feature-card">
         <span class="feature-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="5" width="6" height="6" rx="1"/><path d="m3 17 2 2 4-4M13 6h8M13 12h8M13 18h8"/></svg></span>
@@ -1415,8 +1409,8 @@
       <div class="wn-item">
         <span class="wn-date">Apr 2026</span>
         <div class="wn-content">
-          <span class="wn-tag notice">Notice</span>
-          <span class="wn-text"><strong>Spotify — invite-only for now</strong> — Spotify's API limits new apps to 5 users in Development Mode. The integration works, but access is restricted until we receive Extended API approval. We are actively working on it.</span>
+          <span class="wn-tag new">New</span>
+          <span class="wn-text"><strong>Spotify — Bring Your Own App</strong> — Spotify's February 2026 policy capped shared apps at 5 users. WindoM now uses a BYOA model: connect your own free Spotify Developer app in ~2 minutes. No shared quota, works for everyone, no Client Secret ever stored.</span>
         </div>
       </div>
       <div class="wn-item">
@@ -1517,7 +1511,7 @@
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 3v10M3 8h10"/></svg>
         </button>
         <div class="faq-a">
-          <p>The Spotify integration is built and works, but it is currently limited to a small number of invited users. This is due to Spotify's API policy — new apps are restricted to 5 users in Development Mode until they receive Extended API access. We are applying for that approval. Once granted, Spotify will be available to everyone with no restrictions.</p>
+          <p>Yes — Spotify uses a <strong>Bring Your Own App</strong> model. Create a free app at <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">developer.spotify.com/dashboard</a>, add the Redirect URI shown in WindoM's Spotify settings, and paste your Client ID. The whole setup takes about 2 minutes. Your Client Secret is never required or stored — WindoM uses PKCE, the standard secure OAuth flow for public clients.</p>
         </div>
       </div>
 

--- a/web/src/components/settings/SettingsNav.tsx
+++ b/web/src/components/settings/SettingsNav.tsx
@@ -16,7 +16,7 @@ const LABELS: Record<SettingsTab, string> = {
 };
 
 /** Tabs that require a signed-in user to be interactive */
-const AUTH_REQUIRED_TABS = new Set<SettingsTab>(['calendar', 'spotify']);
+const AUTH_REQUIRED_TABS = new Set<SettingsTab>(['calendar']);
 
 interface SettingsNavProps {
   active: SettingsTab;

--- a/web/src/components/settings/sections/AccountSettings.tsx
+++ b/web/src/components/settings/sections/AccountSettings.tsx
@@ -12,7 +12,7 @@ function SignedOutView() {
     <div>
       <div className="settings-group">
         <p className="settings-label" style={{ opacity: 0.65, marginBottom: '16px', lineHeight: '1.5' }}>
-          Sign in to connect Google Calendar and Spotify. The rest of the dashboard works without an account.
+          Sign in to connect Google Calendar. The rest of the dashboard works without an account.
         </p>
         <LoginScreen />
       </div>
@@ -253,7 +253,6 @@ function SignedInView() {
   const { user, logout } = useAuth();
   const { get, update } = useSettings();
   const calendarConnected = get('calendarConnected');
-  const spotifyConnected = get('spotifyConnected');
   const [signingOut, setSigningOut] = useState(false);
 
   // Danger zone state
@@ -291,33 +290,6 @@ function SignedInView() {
       throw new Error('Failed to disconnect Google Calendar');
     }
     await update('calendarConnected', false);
-  }
-
-  async function connectSpotify() {
-    try {
-      const redirectUri = chrome.identity.getRedirectURL();
-      const { authUrl } = await apiPost<{ authUrl: string }>(`/oauth/spotify/start?redirectUri=${encodeURIComponent(redirectUri)}`);
-      const redirectUrl = await launchWebAuth(authUrl);
-      const params = new URL(redirectUrl).searchParams;
-      if (params.get('error')) throw new Error(mapOAuthError(params.get('error')!));
-      const code = params.get('code');
-      const state = params.get('state');
-      if (!code || !state) throw new Error('No auth code returned');
-      const { status } = await apiPost<{ status: string }>('/oauth/spotify/exchange', { code, state, redirectUri });
-      if (status !== 'linked') throw new Error('Linking failed');
-      await update('spotifyConnected', true);
-    } catch (err) {
-      throw new Error(mapIntegrationError(err));
-    }
-  }
-
-  async function disconnectSpotify() {
-    const res = await apiFetch('/integrations/spotify', { method: 'DELETE' });
-    if (!res.ok) {
-      console.error('[integrations] Failed to disconnect Spotify:', res.status);
-      throw new Error('Failed to disconnect Spotify');
-    }
-    await update('spotifyConnected', false);
   }
 
   async function handleSignOut() {
@@ -373,14 +345,6 @@ function SignedInView() {
           onConnect={connectGoogle}
           onDisconnect={disconnectGoogle}
           icon={<GoogleCalendarIcon />}
-        />
-        <IntegrationCard
-          provider="spotify"
-          name="Spotify"
-          connected={spotifyConnected}
-          onConnect={connectSpotify}
-          onDisconnect={disconnectSpotify}
-          icon={<SpotifyIcon />}
         />
       </div>
 
@@ -518,10 +482,3 @@ function GoogleCalendarIcon() {
   );
 }
 
-function SpotifyIcon() {
-  return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="#1DB954">
-      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/>
-    </svg>
-  );
-}

--- a/web/src/components/settings/sections/SpotifySettings.tsx
+++ b/web/src/components/settings/sections/SpotifySettings.tsx
@@ -1,42 +1,364 @@
+import { useState, useEffect } from 'react';
+import { useSettings } from '../../../contexts/SettingsContext';
 import { useAuth } from '../../../contexts/AuthContext';
-import { SETTINGS_EVENT } from '../../../lib/settings-events';
+import { apiPost, apiFetch } from '../../../lib/api';
+import { mapOAuthError } from '../../../lib/oauth-errors';
+import { generateCodeVerifier, generateCodeChallenge } from '../../../lib/pkce';
 
-/**
- * Spotify connection settings — full management lives in Settings → Account.
- */
-export function SpotifySettings() {
+const CLIENT_ID_KEY = 'windom_spotify_client_id';
+
+// ── Spotify icon ────────────────────────────────────────────────────────────
+
+function SpotifyIcon({ size = 20 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="#1DB954">
+      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+    </svg>
+  );
+}
+
+// ── Shared PKCE OAuth flow ──────────────────────────────────────────────────
+
+async function runPkceFlow(clientId: string): Promise<void> {
+  const redirectUri = chrome.identity.getRedirectURL();
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+  const { authUrl } = await apiPost<{ authUrl: string }>('/oauth/spotify/start', {
+    clientId,
+    codeChallenge,
+    codeChallengeMethod: 'S256',
+    redirectUri,
+  });
+
+  const redirectUrl = await launchWebAuth(authUrl);
+  const params = new URL(redirectUrl).searchParams;
+  const error = params.get('error');
+  if (error) throw new Error(mapOAuthError(error));
+
+  const code = params.get('code');
+  const state = params.get('state');
+  if (!code || !state) throw new Error('No auth code returned');
+
+  const { status } = await apiPost<{ status: string }>('/oauth/spotify/exchange', {
+    code,
+    state,
+    redirectUri,
+    codeVerifier,
+  });
+  if (status !== 'linked') throw new Error('Linking failed');
+}
+
+function launchWebAuth(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      reject(new Error('Sign-in timed out. Please try again.'));
+    }, 120_000);
+
+    chrome.identity.launchWebAuthFlow({ url, interactive: true }, (redirectUrl) => {
+      clearTimeout(timer);
+      if (settled) return;
+      if (chrome.runtime.lastError || !redirectUrl) {
+        reject(new Error(mapOAuthError(chrome.runtime.lastError?.message ?? 'Auth cancelled')));
+      } else {
+        resolve(redirectUrl);
+      }
+    });
+  });
+}
+
+// ── State 1: No client ID saved ─────────────────────────────────────────────
+
+function NoClientIdState({ onSaved }: { onSaved: () => void }) {
+  const { update } = useSettings();
   const { user } = useAuth();
+  const [clientIdInput, setClientIdInput] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+  const [copied, setCopied] = useState(false);
 
-  if (!user) {
-    return (
-      <div className="auth-required-notice">
-        <p>
-          Sign in to connect Spotify.{' '}
+  const redirectUri = chrome.identity.getRedirectURL();
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(redirectUri);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  async function handleSaveAndConnect() {
+    const trimmed = clientIdInput.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    setError('');
+    try {
+      await runPkceFlow(trimmed);
+      await chrome.storage.local.set({ [CLIENT_ID_KEY]: trimmed });
+      await update('spotifyConnected', true);
+      onSaved();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Connection failed';
+      if (/cancelled|canceled/i.test(msg)) {
+        setError('Connection cancelled.');
+      } else if (/invalid_client|INVALID_CLIENT/i.test(msg) || /Invalid Client/i.test(msg)) {
+        setError('Invalid Client ID — check your app settings at developer.spotify.com.');
+      } else if (!user) {
+        setError('You must be signed in to connect Spotify.');
+      } else {
+        setError(msg);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      <div className="settings-group">
+        <label className="settings-label">Connect Spotify</label>
+        <p className="settings-hint" style={{ marginBottom: '16px', lineHeight: '1.6' }}>
+          Connect your own free Spotify Developer app — no shared quota, works for everyone.
+        </p>
+
+        <ol style={{ paddingLeft: '18px', margin: '0 0 16px', lineHeight: '1.7' }} className="settings-hint">
+          <li>
+            Go to{' '}
+            <a
+              href="https://developer.spotify.com/dashboard"
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: '#1DB954' }}
+            >
+              developer.spotify.com/dashboard
+            </a>{' '}
+            and create a free app.
+          </li>
+          <li>In your app settings, add this Redirect URI:</li>
+        </ol>
+
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '16px' }}>
+          <input
+            type="text"
+            readOnly
+            value={redirectUri}
+            className="settings-input"
+            style={{ flex: 1, fontSize: '12px', fontFamily: 'monospace', opacity: 0.8, cursor: 'text' }}
+            onFocus={(e) => e.currentTarget.select()}
+          />
           <button
             type="button"
-            className="auth-required-link"
-            onClick={() => document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.OPEN_ACCOUNT))}
+            className="settings-save-btn"
+            style={{ flexShrink: 0, padding: '8px 12px', fontSize: '12px' }}
+            onClick={handleCopy}
           >
-            Go to Account settings
+            {copied ? 'Copied!' : 'Copy'}
           </button>
-        </p>
+        </div>
+
+        <ol start={3} style={{ paddingLeft: '18px', margin: '0 0 12px', lineHeight: '1.7' }} className="settings-hint">
+          <li>Copy your Client ID from the app dashboard and paste it below.</li>
+        </ol>
+
+        <input
+          type="text"
+          placeholder="Spotify Client ID"
+          value={clientIdInput}
+          onChange={(e) => { setClientIdInput(e.target.value); setError(''); }}
+          className="settings-input"
+          style={{ marginBottom: '8px', fontFamily: 'monospace', fontSize: '13px' }}
+          onKeyDown={(e) => e.key === 'Enter' && handleSaveAndConnect()}
+        />
+        {error && <p className="auth-field-error" style={{ marginBottom: '8px' }}>{error}</p>}
+        <button
+          type="button"
+          className="integration-connect-btn"
+          disabled={busy || !clientIdInput.trim() || !user}
+          onClick={handleSaveAndConnect}
+          style={{ width: '100%' }}
+        >
+          {busy ? 'Connecting…' : 'Save & Connect'}
+        </button>
+        {!user && (
+          <p className="settings-hint" style={{ marginTop: '8px', opacity: 0.6 }}>
+            Sign in to your WindoM account first to connect Spotify.
+          </p>
+        )}
       </div>
+    </div>
+  );
+}
+
+// ── State 2: Client ID saved but not connected ──────────────────────────────
+
+function SavedNotConnectedState({ clientId, onConnected, onChangeApp }: { clientId: string; onConnected: () => void; onChangeApp: () => void }) {
+  const { update } = useSettings();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleConnect() {
+    setBusy(true);
+    setError('');
+    try {
+      await runPkceFlow(clientId);
+      await update('spotifyConnected', true);
+      onConnected();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Connection failed';
+      if (/cancelled|canceled/i.test(msg)) {
+        setError('Connection cancelled.');
+      } else if (/invalid_client|INVALID_CLIENT/i.test(msg) || /Invalid Client/i.test(msg)) {
+        setError('Invalid Client ID — check your app settings at developer.spotify.com.');
+      } else {
+        setError(msg);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="settings-group">
+      <label className="settings-label">Spotify</label>
+      <div className="integration-card">
+        <div className="integration-icon spotify">
+          <SpotifyIcon />
+        </div>
+        <div className="integration-info">
+          <div className="integration-name">Spotify</div>
+          <div className="integration-status">Not connected</div>
+        </div>
+        <button
+          type="button"
+          className="integration-connect-btn"
+          disabled={busy}
+          onClick={handleConnect}
+        >
+          {busy ? '…' : 'Connect'}
+        </button>
+      </div>
+      {error && <p className="integration-error">{error}</p>}
+      <p className="settings-hint" style={{ marginTop: '8px' }}>
+        App: <code style={{ fontSize: '12px', opacity: 0.8 }}>{clientId.slice(0, 8)}…</code>
+        {' '}
+        <button
+          type="button"
+          className="auth-required-link"
+          onClick={onChangeApp}
+          style={{ fontSize: '12px' }}
+        >
+          Change app
+        </button>
+      </p>
+    </div>
+  );
+}
+
+// ── State 3: Connected ──────────────────────────────────────────────────────
+
+function ConnectedState({ clientId, onDisconnected }: { clientId: string; onDisconnected: () => void }) {
+  const { update } = useSettings();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function handleDisconnect() {
+    setBusy(true);
+    setError('');
+    try {
+      const res = await apiFetch('/integrations/spotify', { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to disconnect Spotify');
+      await chrome.storage.local.remove(CLIENT_ID_KEY);
+      await update('spotifyConnected', false);
+      onDisconnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Disconnect failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="settings-group">
+      <label className="settings-label">Spotify</label>
+      <div className="integration-card">
+        <div className="integration-icon spotify">
+          <SpotifyIcon />
+        </div>
+        <div className="integration-info">
+          <div className="integration-name">Spotify</div>
+          <div className="integration-status connected">Connected</div>
+        </div>
+        <button
+          type="button"
+          className="integration-disconnect-btn"
+          disabled={busy}
+          onClick={handleDisconnect}
+        >
+          {busy ? '…' : 'Disconnect'}
+        </button>
+      </div>
+      {error && <p className="integration-error">{error}</p>}
+      <p className="settings-hint" style={{ marginTop: '8px', opacity: 0.6 }}>
+        App: <code style={{ fontSize: '12px' }}>{clientId.slice(0, 8)}…</code>
+      </p>
+    </div>
+  );
+}
+
+// ── Root component ──────────────────────────────────────────────────────────
+
+type SpotifyState = 'loading' | 'no-client-id' | 'saved-not-connected' | 'connected';
+
+export function SpotifySettings() {
+  const { get } = useSettings();
+  const spotifyConnected = get('spotifyConnected');
+
+  const [uiState, setUiState] = useState<SpotifyState>('loading');
+  const [savedClientId, setSavedClientId] = useState<string>('');
+
+  useEffect(() => {
+    void chrome.storage.local.get(CLIENT_ID_KEY, (result) => {
+      const clientId = (result[CLIENT_ID_KEY] as string | undefined) ?? '';
+      setSavedClientId(clientId);
+      if (!clientId) {
+        setUiState('no-client-id');
+      } else if (spotifyConnected) {
+        setUiState('connected');
+      } else {
+        setUiState('saved-not-connected');
+      }
+    });
+  }, [spotifyConnected]);
+
+  function handleChangeApp() {
+    chrome.storage.local.remove(CLIENT_ID_KEY, () => {
+      setSavedClientId('');
+      setUiState('no-client-id');
+    });
+  }
+
+  if (uiState === 'loading') {
+    return <p className="settings-label" style={{ opacity: 0.5 }}>Loading…</p>;
+  }
+
+  if (uiState === 'no-client-id') {
+    return <NoClientIdState onSaved={() => setUiState('connected')} />;
+  }
+
+  if (uiState === 'saved-not-connected') {
+    return (
+      <SavedNotConnectedState
+        clientId={savedClientId}
+        onConnected={() => setUiState('connected')}
+        onChangeApp={handleChangeApp}
+      />
     );
   }
 
   return (
-    <div className="auth-required-notice">
-      <p>
-        Manage your Spotify connection in{' '}
-        <button
-          type="button"
-          className="auth-required-link"
-          onClick={() => document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.OPEN_ACCOUNT))}
-        >
-          Account settings
-        </button>
-        .
-      </p>
-    </div>
+    <ConnectedState
+      clientId={savedClientId}
+      onDisconnected={() => setUiState('no-client-id')}
+    />
   );
 }

--- a/web/src/lib/pkce.ts
+++ b/web/src/lib/pkce.ts
@@ -1,0 +1,19 @@
+/** Generate a cryptographically random PKCE code verifier (RFC 7636). */
+export function generateCodeVerifier(): string {
+  const array = new Uint8Array(64);
+  crypto.getRandomValues(array);
+  return btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+/** Derive the S256 PKCE code challenge from a code verifier. */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+  const data = new TextEncoder().encode(verifier);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return btoa(String.fromCharCode(...new Uint8Array(digest)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}


### PR DESCRIPTION
## Summary

- Replaces the shared Spotify OAuth app (capped at 5 users by Spotify's Feb 2026 policy) with a Bring Your Own App model using PKCE — no shared quota, no Client Secret ever stored
- Each user registers their own free Spotify Developer app, pastes their Client ID into a new 3-state settings UI, and completes a PKCE flow entirely in their browser
- Backend remains the token custodian (AES-GCM encryption unchanged); only the OAuth start/exchange and refresh paths are extended to support `providerClientId`

## Changes

**Backend:** `providerClientId` + `clientId` DB columns, migration, PKCE exchange in `oauth.service`, PKCE start/exchange in `oauth-spotify.controller`, `pkceClientId` refresh path in `token-refresh.service`, routing in `spotify.service`

**Extension:** new `pkce.ts` helpers, full 3-state `SpotifySettings` UI, Spotify card removed from `AccountSettings`, `spotify` removed from `AUTH_REQUIRED_TABS`

**Docs:** landing page updated — removed "Limited" badge, invite-only copy, and unused CSS; FAQ and what's-new rewritten for BYOA

## Closes

Closes #67, #68, #69, #70, #71, #72, #73, #74, #75, #76, #44

## Test plan

- [ ] DB migration applies cleanly (`npm run db:migrate`)
- [ ] `POST /oauth/spotify/start` with `{ clientId, codeChallenge, codeChallengeMethod }` returns auth URL with `code_challenge` param
- [ ] `POST /oauth/spotify/exchange` with `codeVerifier` stores `providerClientId` on the account row
- [ ] Token refresh for a BYOA account sends `client_id` in body, no `Authorization: Basic` header
- [ ] Legacy accounts (providerClientId null) still refresh via Basic auth
- [ ] Spotify settings tab accessible without signing in
- [ ] Full State 1 → 3 flow: enter Client ID → PKCE popup → connected
- [ ] Disconnect clears `windom_spotify_client_id` and sets `spotifyConnected = false`
- [ ] AccountSettings shows only Google Calendar card
- [ ] `tsc --noEmit` passes in both `web/` and `backend/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)