### PR TITLE
fix: unblock CI lint and pin deploy action

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@v1.5
 
       - name: Deploy to Fly.io
         working-directory: backend

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -62,6 +62,7 @@ export async function buildApp({ skipRateLimit, ...overrides }: BuildAppOptions 
   // Security headers: HSTS, X-Frame-Options, X-Content-Type-Options, etc.
   // CSP is permissive here because most responses are JSON; the HTML pages served
   // (reset-password, verify-email) load fonts from Google so we allow that origin.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- @fastify/helmet options type doesn't satisfy FastifyPluginCallback generic exactly; safe in practice
   await app.register(fastifyHelmet, {
     contentSecurityPolicy: {
       directives: {


### PR DESCRIPTION
## What
- Suppress false-positive ESLint error on `@fastify/helmet` registration in `backend/src/app.ts`
- Pin `superfly/flyctl-actions/setup-flyctl` from `@master` to `@v1.5`

## Why
The helmet plugin's option types don't satisfy Fastify's `FastifyPluginCallback` generic exactly, causing `npm run lint` to fail on every PR with a `no-unsafe-argument` error. The `@master` pin is a supply chain risk — any future commit to that upstream branch could inject code into the production deploy pipeline.

## How
Added a scoped `eslint-disable-next-line` with an explanation comment directly above the helmet `app.register` call. Pinned flyctl-actions to `v1.5` — confirmed as the latest stable release via the upstream GitHub releases page.

## Test plan
- [ ] `cd backend && npm run lint` exits 0
- [ ] CI lint step passes on this PR
- [ ] Deploy workflow file still references the correct action at `v1.5`

Closes #110, #111

Generated by [Claude-Bot] of [@Yehuda Briskman]