### PR TITLE
perf(db): add missing indexes on oauth_accounts and refresh_sessions

### DIFF
--- a/backend/drizzle/0005_overrated_raider.sql
+++ b/backend/drizzle/0005_overrated_raider.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS "oauth_accounts_user_provider_idx" ON "oauth_accounts" USING btree ("user_id","provider");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "refresh_sessions_rotated_from_idx" ON "refresh_sessions" USING btree ("rotated_from_id");

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -5,6 +5,7 @@ import {
   timestamp,
   boolean,
   inet,
+  index,
   uniqueIndex,
   integer,
   jsonb,
@@ -42,7 +43,11 @@ export const refreshSessions = pgTable(
     renewalCount: integer('renewal_count').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [uniqueIndex('refresh_sessions_token_lookup_idx').on(table.tokenLookup)],
+  (table) => [
+    uniqueIndex('refresh_sessions_token_lookup_idx').on(table.tokenLookup),
+    // Enables O(1) lookup for token reuse detection (WHERE rotated_from_id = $1)
+    index('refresh_sessions_rotated_from_idx').on(table.rotatedFromId),
+  ],
 );
 
 // ── OAuth Accounts ─────────────────────────────────────────────────────────
@@ -64,7 +69,12 @@ export const oauthAccounts = pgTable(
     providerClientId: text('provider_client_id'),
     updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
   },
-  (table) => [uniqueIndex('oauth_accounts_provider_user_idx').on(table.provider, table.providerUserId)],
+  (table) => [
+    uniqueIndex('oauth_accounts_provider_user_idx').on(table.provider, table.providerUserId),
+    // Enables O(1) lookup for per-user provider queries (WHERE user_id = $1 AND provider = $2)
+    // Used by spotify.service, calendar.service, and integrations.service on every request
+    index('oauth_accounts_user_provider_idx').on(table.userId, table.provider),
+  ],
 );
 
 // ── OAuth States (for CSRF protection) ────────────────────────────────────


### PR DESCRIPTION
## What
- Add `oauth_accounts_user_provider_idx` on `(user_id, provider)`
- Add `refresh_sessions_rotated_from_idx` on `(rotated_from_id)`
- Generated Drizzle migration `0005_overrated_raider.sql`

## Why
Every Spotify and Calendar API request queries `oauth_accounts` with `WHERE user_id = $1 AND provider = $2`, but the table only had an index on `(provider, providerUserId)` — making these full table scans. Token reuse detection runs `WHERE rotated_from_id = $1` on every token refresh with no index at all. Both become sequential scans as the user base grows.

## How
Added two `index()` calls to the Drizzle schema definitions and ran `npm run db:generate` to produce the migration. Migration applies automatically via `entrypoint.sh` on Fly.io deploy — no manual step needed. The generated SQL uses `CREATE INDEX IF NOT EXISTS` so it's safe to run on an already-migrated DB.

## Test plan
- [ ] CI migration step passes against the test Postgres instance
- [ ] `psql` on the deployed DB shows both new indexes after deploy: `\d oauth_accounts` and `\d refresh_sessions`
- [ ] No existing queries broken (indexes are additive — no column changes)

Closes #109

Generated by [Claude-Bot] of [@Yehuda Briskman]