### PR TITLE
fix(auth): harden JWT claims and refresh cookie Secure flag

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -62,7 +62,6 @@ export async function buildApp({ skipRateLimit, ...overrides }: BuildAppOptions 
   // Security headers: HSTS, X-Frame-Options, X-Content-Type-Options, etc.
   // CSP is permissive here because most responses are JSON; the HTML pages served
   // (reset-password, verify-email) load fonts from Google so we allow that origin.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- @fastify/helmet options type doesn't satisfy FastifyPluginCallback generic exactly; safe in practice
   await app.register(fastifyHelmet, {
     contentSecurityPolicy: {
       directives: {

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -7,8 +7,11 @@ import * as authService from '../services/auth.service.js';
 
 const cookieOpts = {
   httpOnly: true,
-  secure: config.isProd,
-  // SameSite=None requires Secure; in dev use Lax so the cookie works over plain HTTP.
+  // Always true — modern browsers exempt localhost from the Secure requirement,
+  // so local dev still works. Never send refresh tokens over plain HTTP.
+  secure: true,
+  // SameSite=None is required for cross-origin requests from the extension;
+  // in dev use Lax (localhost is same-site for the backend).
   sameSite: config.isProd ? ('none' as const) : ('lax' as const),
   // Path is /auth (not /auth/refresh) so the cookie is also sent to /auth/logout,
   // allowing the logout handler to revoke the session server-side.

--- a/backend/src/lib/jwt.ts
+++ b/backend/src/lib/jwt.ts
@@ -17,11 +17,17 @@ export async function signAccessToken(payload: AccessTokenPayload): Promise<stri
     .setSubject(payload.sub)
     .setIssuedAt()
     .setExpirationTime(ACCESS_TTL)
+    .setIssuer('windom-api')
+    .setAudience('windom-extension')
     .sign(accessSecret);
 }
 
 export async function verifyAccessToken(token: string): Promise<AccessTokenPayload> {
-  const { payload } = await jwtVerify(token, accessSecret, { algorithms: ['HS256'] });
+  const { payload } = await jwtVerify(token, accessSecret, {
+    algorithms: ['HS256'],
+    issuer: 'windom-api',
+    audience: 'windom-extension',
+  });
   return {
     sub: payload.sub as string,
     email: (payload['email'] as string | null) ?? null,


### PR DESCRIPTION
## What
- JWT access tokens now carry `iss: windom-api` / `aud: windom-extension` claims; `verifyAccessToken` enforces both
- Refresh token cookie `Secure` flag is always `true` (browsers already exempt localhost; removes risk of plain-HTTP transmission in any environment)
- Removed now-stale `eslint-disable` directive for `@fastify/helmet` (types were fixed in Phase 1)

## Why
Tokens without issuer/audience constraints can be replayed cross-service. The conditional `Secure` flag meant a misconfigured non-prod environment could transmit refresh tokens over HTTP.

## How
`src/lib/jwt.ts`: added `.setIssuer` / `.setAudience` on sign; added `issuer` / `audience` options on verify.
`src/controllers/auth.controller.ts`: hardcoded `secure: true` with an explanatory comment.

## Test plan
- [ ] CI lint + build passes
- [ ] CI integration tests pass (token sign/verify round-trip covered by existing auth tests)
- [ ] Manual: login flow works in dev; refresh cookie is `Secure` in browser DevTools

Closes #106
Closes #108

Generated by [Claude-Code-Agent] [Claude-Bot] of [@Yehuda Briskman]