### PR TITLE
fix(oauth): PKCE for Google and lock redirect URI to extension ID

### DIFF
--- a/backend/src/controllers/auth-google.controller.ts
+++ b/backend/src/controllers/auth-google.controller.ts
@@ -8,8 +8,11 @@ import * as oauthService from '../services/oauth.service.js';
 
 const cookieOpts = {
   httpOnly: true,
-  secure: config.isProd,
-  // SameSite=None requires Secure; in dev use Lax so the cookie works over plain HTTP.
+  // Always true — modern browsers exempt localhost from the Secure requirement,
+  // so local dev still works. Never send refresh tokens over plain HTTP.
+  secure: true,
+  // SameSite=None is required for cross-origin requests from the extension;
+  // in dev use Lax (localhost is same-site for the backend).
   sameSite: config.isProd ? ('none' as const) : ('lax' as const),
   // Path is /auth (not /auth/refresh) so the cookie is also sent to /auth/logout,
   // allowing the logout handler to revoke the session server-side.
@@ -21,6 +24,7 @@ const exchangeSchema = z.object({
   code: z.string(),
   state: z.string(),
   redirectUri: z.string().url(),
+  codeVerifier: z.string().optional(),
 });
 
 async function handleGoogleCodeExchange(
@@ -28,12 +32,14 @@ async function handleGoogleCodeExchange(
   redirectUri: string,
   req: FastifyRequest,
   reply: FastifyReply,
+  codeVerifier?: string,
 ): Promise<void> {
   const exchangeResult = await oauthService.exchangeGoogleCode(
     code,
     redirectUri,
     config.GOOGLE_CLIENT_ID ?? '',
     config.GOOGLE_CLIENT_SECRET ?? '',
+    codeVerifier,
   );
 
   if (!exchangeResult.ok) {
@@ -54,7 +60,11 @@ async function handleGoogleCodeExchange(
 }
 
 export async function startGoogleAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const { redirectUri } = req.query as { redirectUri?: string };
+  const { redirectUri, codeChallenge, codeChallengeMethod } = req.query as {
+    redirectUri?: string;
+    codeChallenge?: string;
+    codeChallengeMethod?: string;
+  };
   const effectiveUri = redirectUri ?? config.GOOGLE_REDIRECT_URI ?? '';
 
   if (!effectiveUri) {
@@ -63,7 +73,7 @@ export async function startGoogleAuthController(req: FastifyRequest, reply: Fast
   }
 
   // Validate redirect URI before creating state (fail fast — avoids orphaned state rows)
-  if (!isAllowedRedirectUri(effectiveUri, config.GOOGLE_REDIRECT_URI)) {
+  if (!isAllowedRedirectUri(effectiveUri, config.GOOGLE_REDIRECT_URI, config.EXTENSION_REDIRECT_BASE)) {
     void reply.status(400).send({ error: 'Redirect URI not allowed', message: 'This extension ID is not registered for Google sign-in. Contact support.' });
     return;
   }
@@ -78,6 +88,10 @@ export async function startGoogleAuthController(req: FastifyRequest, reply: Fast
     access_type: 'offline',
     prompt: 'select_account',
   });
+  if (codeChallenge) {
+    params.set('code_challenge', codeChallenge);
+    params.set('code_challenge_method', codeChallengeMethod ?? 'S256');
+  }
 
   void reply.send({ authUrl: `${GOOGLE_AUTH_URL}?${params}` });
 }
@@ -89,7 +103,7 @@ export async function exchangeGoogleAuthController(req: FastifyRequest, reply: F
     return;
   }
 
-  if (!isAllowedRedirectUri(parsed.data.redirectUri, config.GOOGLE_REDIRECT_URI)) {
+  if (!isAllowedRedirectUri(parsed.data.redirectUri, config.GOOGLE_REDIRECT_URI, config.EXTENSION_REDIRECT_BASE)) {
     void reply.status(400).send({ error: 'Redirect URI not allowed' });
     return;
   }
@@ -100,7 +114,7 @@ export async function exchangeGoogleAuthController(req: FastifyRequest, reply: F
     return;
   }
 
-  await handleGoogleCodeExchange(parsed.data.code, parsed.data.redirectUri, req, reply);
+  await handleGoogleCodeExchange(parsed.data.code, parsed.data.redirectUri, req, reply, parsed.data.codeVerifier);
 }
 
 export async function callbackGoogleAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {

--- a/backend/src/controllers/oauth-google.controller.ts
+++ b/backend/src/controllers/oauth-google.controller.ts
@@ -9,6 +9,7 @@ const exchangeSchema = z.object({
   code: z.string(),
   state: z.string(),
   redirectUri: z.string().url(),
+  codeVerifier: z.string().optional(),
 });
 
 async function handleGoogleOAuthExchange(
@@ -16,12 +17,14 @@ async function handleGoogleOAuthExchange(
   code: string,
   redirectUri: string,
   reply: FastifyReply,
+  codeVerifier?: string,
 ): Promise<void> {
   const exchangeResult = await oauthService.exchangeGoogleCode(
     code,
     redirectUri,
     config.GOOGLE_CLIENT_ID ?? '',
     config.GOOGLE_CLIENT_SECRET ?? '',
+    codeVerifier,
   );
 
   if (!exchangeResult.ok) {
@@ -47,7 +50,11 @@ async function handleGoogleOAuthExchange(
 }
 
 export async function startGoogleOAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const { redirectUri } = req.query as { redirectUri?: string };
+  const { redirectUri, codeChallenge, codeChallengeMethod } = req.query as {
+    redirectUri?: string;
+    codeChallenge?: string;
+    codeChallengeMethod?: string;
+  };
   const effectiveUri = redirectUri ?? config.GOOGLE_OAUTH_REDIRECT_URI ?? '';
 
   if (!effectiveUri) {
@@ -56,7 +63,7 @@ export async function startGoogleOAuthController(req: FastifyRequest, reply: Fas
   }
 
   // Validate redirect URI before creating state (fail fast — avoids orphaned state rows)
-  if (!isAllowedRedirectUri(effectiveUri, config.GOOGLE_OAUTH_REDIRECT_URI)) {
+  if (!isAllowedRedirectUri(effectiveUri, config.GOOGLE_OAUTH_REDIRECT_URI, config.EXTENSION_REDIRECT_BASE)) {
     void reply.status(400).send({ error: 'Redirect URI not allowed', message: 'This extension ID is not registered for Google Calendar. Contact support.' });
     return;
   }
@@ -71,6 +78,10 @@ export async function startGoogleOAuthController(req: FastifyRequest, reply: Fas
     access_type: 'offline',
     prompt: 'consent',
   });
+  if (codeChallenge) {
+    params.set('code_challenge', codeChallenge);
+    params.set('code_challenge_method', codeChallengeMethod ?? 'S256');
+  }
 
   void reply.send({ authUrl: `${GOOGLE_AUTH_URL}?${params}` });
 }
@@ -82,7 +93,7 @@ export async function exchangeGoogleOAuthController(req: FastifyRequest, reply: 
     return;
   }
 
-  if (!isAllowedRedirectUri(parsed.data.redirectUri, config.GOOGLE_OAUTH_REDIRECT_URI)) {
+  if (!isAllowedRedirectUri(parsed.data.redirectUri, config.GOOGLE_OAUTH_REDIRECT_URI, config.EXTENSION_REDIRECT_BASE)) {
     void reply.status(400).send({ error: 'Redirect URI not allowed' });
     return;
   }
@@ -93,7 +104,7 @@ export async function exchangeGoogleOAuthController(req: FastifyRequest, reply: 
     return;
   }
 
-  await handleGoogleOAuthExchange(stateResult.data.userId, parsed.data.code, parsed.data.redirectUri, reply);
+  await handleGoogleOAuthExchange(stateResult.data.userId, parsed.data.code, parsed.data.redirectUri, reply, parsed.data.codeVerifier);
 }
 
 export async function callbackGoogleOAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {

--- a/backend/src/lib/request.ts
+++ b/backend/src/lib/request.ts
@@ -5,13 +5,22 @@ import type { SessionMeta } from '../types/auth.types.js';
  * Check whether a redirect URI is allowed for an OAuth exchange.
  * Accepts:
  *   - An exact match against `configured` (the server-side env value for this provider)
- *   - Any https://*.chromiumapp.org/* URI (Chrome identity API flow, varies by extension ID)
+ *   - A https://*.chromiumapp.org URI — if `extensionRedirectBase` is set, only URIs that
+ *     start with that base are accepted (locks to a specific extension ID); otherwise any
+ *     chromiumapp.org URI is accepted (dev/test fallback).
  */
-export function isAllowedRedirectUri(uri: string, configured: string | undefined): boolean {
+export function isAllowedRedirectUri(
+  uri: string,
+  configured: string | undefined,
+  extensionRedirectBase?: string,
+): boolean {
   if (configured && uri === configured) return true;
   try {
     const u = new URL(uri);
-    if (u.protocol === 'https:' && u.hostname.endsWith('.chromiumapp.org')) return true;
+    if (u.protocol === 'https:' && u.hostname.endsWith('.chromiumapp.org')) {
+      if (extensionRedirectBase) return uri.startsWith(extensionRedirectBase);
+      return true; // dev/test: no specific extension ID configured, allow any
+    }
   } catch { return false; }
   return false;
 }

--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -152,13 +152,23 @@ export async function exchangeGoogleCode(
   redirectUri: string,
   clientId: string,
   clientSecret: string,
+  codeVerifier?: string,
 ): Promise<Result<{ tokens: GoogleTokenResponse; userInfo: GoogleUserInfo }, OAuthError>> {
   let tokenRes: Response;
   try {
+    const bodyParams: Record<string, string> = {
+      code,
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uri: redirectUri,
+      grant_type: 'authorization_code',
+    };
+    if (codeVerifier) bodyParams['code_verifier'] = codeVerifier;
+
     tokenRes = await fetch(GOOGLE_TOKEN_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({ code, client_id: clientId, client_secret: clientSecret, redirect_uri: redirectUri, grant_type: 'authorization_code' }),
+      body: new URLSearchParams(bodyParams),
     });
   } catch {
     return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };


### PR DESCRIPTION
## What
- `isAllowedRedirectUri` now restricts chromiumapp.org URIs to the configured `EXTENSION_REDIRECT_BASE` (any extension ID was previously accepted)
- Google sign-in and Calendar link flows accept `codeChallenge`/`codeChallengeMethod` on `/start` and `codeVerifier` on `/exchange`, forwarding them to Google
- Fixed missed `secure: config.isProd` → `secure: true` on the cookie in `auth-google.controller.ts`

## Why
Any installed Chrome extension could previously redirect to the backend's Google OAuth flow by using their own chromiumapp.org URL. The PKCE gap meant authorization codes could be intercepted since Google wasn't verifying a code challenge.

## How
`src/lib/request.ts`: added optional `extensionRedirectBase` param; chromiumapp.org check now starts-with that base when set.
`src/services/oauth.service.ts`: `exchangeGoogleCode` accepts optional `codeVerifier` and includes it in the token body.
Both Google controllers: query params for PKCE challenge on start, body field for verifier on exchange.

## Test plan
- [ ] CI lint + build passes
- [ ] `isAllowedRedirectUri` unit: URI from wrong extension ID rejected when `extensionRedirectBase` is set
- [ ] Google sign-in flow works end-to-end with PKCE (manual test in extension)
- [ ] Google Calendar link flow works end-to-end with PKCE (manual test in extension)
- [ ] Existing flow without `codeChallenge` still works (PKCE is optional/backwards-compatible)

Closes #105
Closes #107

Generated by [Claude-Code-Agent] [Claude-Bot] of [@Yehuda Briskman]