### PR TITLE
fix(backend): structured logger, email error handling, type cast

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "jose": "^5.9.6",
         "nodemailer": "^8.0.5",
         "pg": "^8.13.1",
+        "pino": "^10.3.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,7 @@
     "jose": "^5.9.6",
     "nodemailer": "^8.0.5",
     "pg": "^8.13.1",
+    "pino": "^10.3.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -43,10 +44,10 @@
     "@types/pg": "^8.11.10",
     "@vitest/coverage-v8": "^4.1.0",
     "drizzle-kit": "^0.28.1",
+    "esbuild": "^0.27.7",
     "eslint": "^10.0.3",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
-    "esbuild": "^0.27.7",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.57.1",

--- a/backend/src/controllers/auth-email.controller.ts
+++ b/backend/src/controllers/auth-email.controller.ts
@@ -323,7 +323,7 @@ export async function forgotPasswordController(req: FastifyRequest, reply: Fasti
   const parsed = forgotSchema.safeParse(req.body);
   if (parsed.success) {
     await authEmailService.sendPasswordReset(parsed.data.email).catch((err: unknown) => {
-      console.error('[forgotPassword] email send failed:', err);
+      req.log.error({ err }, 'forgotPassword: email send failed');
     });
   }
   void reply.send({ ok: true });

--- a/backend/src/controllers/spotify.controller.ts
+++ b/backend/src/controllers/spotify.controller.ts
@@ -62,5 +62,6 @@ export async function getSpotifyMeController(req: FastifyRequest, reply: Fastify
 
 // Validate that a value is a valid playback command
 export function parsePlaybackCommand(value: string): PlaybackCommand | null {
-  return commandSchema.safeParse(value).success ? (value as PlaybackCommand) : null;
+  const result = commandSchema.safeParse(value);
+  return result.success ? result.data : null;
 }

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
 import { config } from '../config.js';
+import { logger } from '../lib/logger.js';
 import * as schema from './schema.js';
 
 const { Pool } = pg;
@@ -16,7 +17,7 @@ export const pool = new Pool({
 });
 
 pool.on('error', (err) => {
-  console.error('Unexpected error on idle Postgres client', err);
+  logger.error({ err }, 'Unexpected error on idle Postgres client');
 });
 
 export const db = drizzle(pool, { schema });

--- a/backend/src/lib/email.ts
+++ b/backend/src/lib/email.ts
@@ -1,5 +1,6 @@
 import nodemailer from 'nodemailer';
 import { config } from '../config.js';
+import { logger } from './logger.js';
 
 // ── Transporter (singleton) ────────────────────────────────────────────────
 
@@ -184,7 +185,7 @@ function buildEmail(opts: {
 
 async function send(to: string, subject: string, html: string): Promise<void> {
   if (!transporter) {
-    console.warn(`[email] SMTP not configured — skipping email to ${to}: "${subject}"`);
+    logger.warn({ to, subject }, 'email: SMTP not configured — skipping send');
     return;
   }
   await transporter.sendMail({

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,0 +1,9 @@
+import pino from 'pino';
+import { config } from '../config.js';
+
+/**
+ * Module-level pino logger for service/library code that runs outside a
+ * request context (no `req.log` available). Uses the same log level as the
+ * Fastify app so dev and production verbosity is consistent.
+ */
+export const logger = pino({ level: config.isProd ? 'info' : 'debug' });

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -12,6 +12,7 @@ import {
   revokeAllUserSessions,
 } from './session.service.js';
 import { sendVerification } from './auth-email.service.js';
+import { logger } from '../lib/logger.js';
 import type { Result, TokenPair, SessionMeta, AuthError } from '../types/auth.types.js';
 
 /** Register a new user with email + password. Returns TOKEN_PAIR or EMAIL_TAKEN. */
@@ -28,7 +29,7 @@ export async function register(
   const [user] = await db.insert(users).values({ email, name, passwordHash }).returning();
 
   // Send verification email — fire-and-forget so register doesn't fail on email errors
-  void sendVerification(user.id).catch((err) => console.error('[register] verification email failed:', err));
+  void sendVerification(user.id).catch((err) => logger.error({ err }, 'register: verification email failed'));
 
   const accessToken = await signAccessToken({ sub: user.id, email: user.email, name: user.name, emailVerified: false });
   const rawRefreshToken = await createSession(user.id, meta);
@@ -66,35 +67,35 @@ export async function refresh(
 ): Promise<Result<TokenPair, AuthError>> {
   const session = await findSessionByToken(rawToken);
   if (!session) {
-    console.warn('[auth.service:refresh] SESSION_NOT_FOUND — token revoked, expired, or invalid (may be a multi-tab race)');
+    logger.warn('refresh: SESSION_NOT_FOUND — token revoked, expired, or invalid (may be a multi-tab race)');
     return { ok: false, error: 'SESSION_NOT_FOUND' };
   }
 
   if (isRenewalCapReached(session.renewalCount)) {
-    console.warn(`[auth.service:refresh] SESSION_LIMIT_REACHED for session ${session.id} (renewalCount=${session.renewalCount})`);
+    logger.warn({ sessionId: session.id, renewalCount: session.renewalCount }, 'refresh: SESSION_LIMIT_REACHED');
     await revokeSession(session.id);
     return { ok: false, error: 'SESSION_LIMIT_REACHED' };
   }
 
   // Token reuse: if a child session already exists, the old cookie was replayed
   if (await hasChildSession(session.id)) {
-    console.error(`[auth.service:refresh] TOKEN_REUSE_DETECTED for session ${session.id} — revoking ALL sessions for user ${session.userId}`);
+    logger.error({ sessionId: session.id, userId: session.userId }, 'refresh: TOKEN_REUSE_DETECTED — revoking ALL sessions for user');
     await revokeAllUserSessions(session.userId);
     return { ok: false, error: 'TOKEN_REUSE_DETECTED' };
   }
 
-  console.warn(`[auth.service:refresh] Rotating session ${session.id} (renewal #${session.renewalCount + 1})`);
+  logger.warn({ sessionId: session.id, renewal: session.renewalCount + 1 }, 'refresh: rotating session');
   await revokeSession(session.id);
 
   const [user] = await db.select().from(users).where(eq(users.id, session.userId)).limit(1);
   if (!user) {
-    console.error(`[auth.service:refresh] USER_NOT_FOUND for userId ${session.userId}`);
+    logger.error({ userId: session.userId }, 'refresh: USER_NOT_FOUND');
     return { ok: false, error: 'USER_NOT_FOUND' };
   }
 
   const accessToken = await signAccessToken({ sub: user.id, email: user.email, name: user.name, emailVerified: user.emailVerified });
   const rawRefreshToken = await createSession(user.id, meta, session.id, session.renewalCount + 1);
-  console.warn(`[auth.service:refresh] New session created for user ${user.id}`);
+  logger.warn({ userId: user.id }, 'refresh: new session created');
   return { ok: true, data: { accessToken, rawRefreshToken } };
 }
 


### PR DESCRIPTION
## What
- Created `src/lib/logger.ts` — a module-level pino instance for service/library code outside request context
- Replaced all `console.warn`/`console.error` calls in `auth.service.ts`, `lib/email.ts`, `db/client.ts`, and `auth-email.controller.ts` with structured pino/req.log calls
- `parsePlaybackCommand` in `spotify.controller.ts` now uses `result.data` instead of `value as PlaybackCommand`

## Why
`console.*` calls produce unstructured output that doesn't integrate with Fastify's pino pipeline, making log correlation and filtering difficult in production. The Spotify cast bypassed the type system — `result.data` is already the correct type after a successful parse.

## How
`src/lib/logger.ts` exports a pino logger at the same log level as the app. Service/lib imports use it; controller code that has a `req` object uses `req.log` for request correlation. `config.ts` and `db/migrate.ts` intentionally keep `console.*` as they are boot/script code that runs before the app exists.

## Test plan
- [ ] CI lint + build passes
- [ ] All existing auth integration tests pass
- [ ] In dev: session rotation events appear as structured JSON in terminal

Closes #134
Closes #135
Closes #136

Generated by [Claude-Code-Agent] [Claude-Bot] of [@Yehuda Briskman]