### PR TITLE
perf: Cache-Control headers, Spotify 60s poll, stable list keys

### DIFF
--- a/backend/src/controllers/calendar.controller.ts
+++ b/backend/src/controllers/calendar.controller.ts
@@ -14,5 +14,6 @@ export async function getCalendarEventsController(req: FastifyRequest, reply: Fa
     return;
   }
 
+  reply.header('Cache-Control', 'private, max-age=60');
   void reply.send({ events: result.data });
 }

--- a/backend/src/controllers/integrations.controller.ts
+++ b/backend/src/controllers/integrations.controller.ts
@@ -6,6 +6,7 @@ const providerSchema = z.enum(['google', 'spotify']);
 
 export async function getIntegrationsController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const status = await integrationsService.getIntegrations(req.user.sub);
+  reply.header('Cache-Control', 'private, max-age=60');
   void reply.send(status);
 }
 

--- a/backend/src/controllers/me.controller.ts
+++ b/backend/src/controllers/me.controller.ts
@@ -53,6 +53,7 @@ export async function getMeController(req: FastifyRequest, reply: FastifyReply):
     void reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'User not found' });
     return;
   }
+  reply.header('Cache-Control', 'private, max-age=60');
   void reply.send(user);
 }
 

--- a/backend/src/controllers/spotify.controller.ts
+++ b/backend/src/controllers/spotify.controller.ts
@@ -18,6 +18,7 @@ function sendSpotifyError(error: spotifyService.SpotifyError, reply: FastifyRepl
 export async function getNowPlayingController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const result = await spotifyService.getNowPlaying(req.user.sub);
   if (!result.ok) { sendSpotifyError(result.error, reply); return; }
+  reply.header('Cache-Control', 'no-store');
   void reply.send(result.data);
 }
 
@@ -25,6 +26,7 @@ export async function getTopTracksController(req: FastifyRequest, reply: Fastify
   const { limit = '10', time_range = 'short_term' } = req.query as { limit?: string; time_range?: string };
   const result = await spotifyService.getTopTracks(req.user.sub, parseInt(limit, 10) || 10, time_range);
   if (!result.ok) { sendSpotifyError(result.error, reply); return; }
+  reply.header('Cache-Control', 'private, max-age=300');
   void reply.send({ tracks: result.data });
 }
 

--- a/web/src/components/search/SearchOverlay.tsx
+++ b/web/src/components/search/SearchOverlay.tsx
@@ -478,7 +478,7 @@ export function SearchOverlay() {
           <div className="search-dropdown search-overlay-dropdown">
             {visibleSuggestions.map((s, i) => (
               <button
-                key={`${s.kind}-${i}`}
+                key={`${s.kind}-${s.text}`}
                 className={`search-suggestion${i === activeIdx ? ' active' : ''}${s.kind === 'command' ? ' command' : ''}`}
                 onMouseEnter={() => setActiveIdx(i)}
                 onMouseLeave={() => setActiveIdx(-1)}

--- a/web/src/components/settings/sections/LinksSettings.tsx
+++ b/web/src/components/settings/sections/LinksSettings.tsx
@@ -21,7 +21,7 @@ export function LinksSettings() {
           const faviconUrl = getFaviconUrl(link.url);
 
           return (
-            <div key={i} className="link-table-row">
+            <div key={link.url || `link-${i}`} className="link-table-row">
               <div className="link-favicon-cell">
                 {faviconUrl ? (
                   <img

--- a/web/src/components/settings/sections/WeatherSettings.tsx
+++ b/web/src/components/settings/sections/WeatherSettings.tsx
@@ -88,9 +88,9 @@ export function WeatherSettings() {
         />
         {open && results.length > 0 && (
           <div className="city-dropdown">
-            {results.map((r, i) => (
+            {results.map((r) => (
               <button
-                key={i}
+                key={`${r.name}-${r.admin1 ?? ''}-${r.country}`}
                 className="city-dropdown-item"
                 onMouseDown={(e) => { e.preventDefault(); handleSelect(r); }}
               >

--- a/web/src/hooks/useSpotify.ts
+++ b/web/src/hooks/useSpotify.ts
@@ -17,7 +17,7 @@ export interface NowPlayingState {
   track: SpotifyTrack | null;
 }
 
-const POLL_INTERVAL_MS = 30_000;
+const POLL_INTERVAL_MS = 60_000;
 
 export function useSpotify() {
   const { settings } = useSettings();


### PR DESCRIPTION
## What
- `GET /me`, `/integrations`, `/calendar/events`: `Cache-Control: private, max-age=60`
- `GET /spotify/top-tracks`: `Cache-Control: private, max-age=300`
- `GET /spotify/now-playing`: `Cache-Control: no-store` (real-time, must not be stale)
- Spotify now-playing poll interval: 30s → 60s
- Replaced array index keys with stable identifiers in LinksSettings, WeatherSettings, SearchOverlay

## Why
Repeated fetches on tab refocus were hitting the API unnecessarily for data that rarely changes. The 30s Spotify poll was twice as frequent as needed given the local progress ticker fills the gap. Index keys caused React to remount list items on every re-render instead of reconciling them.

## How
Cache-Control headers added directly in each controller's success path. Spotify POLL_INTERVAL_MS constant doubled. List keys now use domain-meaningful fields (url, name+country, kind+text).

## Test plan
- [ ] CI lint + build passes for both backend and web
- [ ] Browser DevTools: `GET /me` response shows `Cache-Control: private, max-age=60`
- [ ] `GET /spotify/now-playing` shows `Cache-Control: no-store`
- [ ] Spotify widget still updates every 60s; progress ticker still increments every second
- [ ] Link and city dropdown lists render correctly with no React key warnings

Closes #123
Closes #124
Closes #143

Generated by [Claude-Code-Agent] [Claude-Bot] of [@Yehuda Briskman]