### PR TITLE
refactor(settings): define sectioned Settings types and LegacySettings [#78]

### DIFF
--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -1,10 +1,105 @@
+// ─── Shared sub-types ────────────────────────────────────────────────────────
+
 export interface QuickLink {
   name: string;
   url: string;
   icon: string;
 }
 
+// ─── Section interfaces ───────────────────────────────────────────────────────
+
+export interface GeneralSettings {
+  userName: string;
+  searchEngine: 'google' | 'bing' | 'duckduckgo' | 'brave';
+  sidebarSide: 'left' | 'right';
+  showGreeting: boolean;
+}
+
+export interface ClockSettings {
+  timeFormat: '12h' | '24h';
+  showSeconds: boolean;
+  leadingZero: boolean;
+  style: 'default' | 'glass' | 'outline';
+  color: string;
+  size: number;
+  weight: 100 | 200 | 400 | 600;
+  showDate: boolean;
+  dateFormat: 'long' | 'short' | 'numeric';
+}
+
+export interface BackgroundSettings {
+  // localBackground lives in chrome.storage.local (can be multi-MB data URL)
+  source: 'unsplash' | 'local';
+  unsplashApiKey: string;
+  unsplashCollectionId: string;
+}
+
+export interface WeatherSettings {
+  show: boolean;
+  unit: 'F' | 'C';
+  location: string;
+  apiKey: string;
+}
+
+export interface WidgetsSettings {
+  showLinks: boolean;
+  showFocus: boolean;
+  showQuotes: boolean;
+  quoteSource: 'local' | 'api';
+  quickLinks: QuickLink[];
+}
+
+/** Device-only — stored under a separate key, never sent to the backend. */
+export interface FocusSettings {
+  mainFocus: string;
+  completed: boolean;
+}
+
+export interface CalendarIntegration {
+  days: 7 | 14 | 30;
+}
+
+export interface SpotifyIntegration {
+  // No user-configurable fields yet; clientId lives in OAuth state
+}
+
+export interface FinanceIntegration {
+  finnhubApiKey: string;
+  watchlistTickers: string[];
+  cryptoWatchlist: string[];
+  showStocks: boolean;
+  showCrypto: boolean;
+}
+
+export interface IntegrationsSettings {
+  calendar: CalendarIntegration;
+  spotify: SpotifyIntegration;
+  finance: FinanceIntegration;
+}
+
+// ─── Top-level Settings ───────────────────────────────────────────────────────
+
 export interface Settings {
+  general: GeneralSettings;
+  clock: ClockSettings;
+  background: BackgroundSettings;
+  weather: WeatherSettings;
+  widgets: WidgetsSettings;
+  /** Stored under a separate chrome.storage.sync key (windom_focus). */
+  focus: FocusSettings;
+  integrations: IntegrationsSettings;
+}
+
+/** Schema version — increment whenever the shape changes incompatibly. */
+export const SETTINGS_VERSION = 2;
+
+// ─── Legacy flat type (kept for migration only) ───────────────────────────────
+
+/**
+ * The old 28-field flat Settings shape (v1).
+ * Used exclusively by the migration function — do not use in new code.
+ */
+export interface LegacySettings {
   userName: string;
   timeFormat: '12h' | '24h';
   showSeconds: boolean;
@@ -37,7 +132,66 @@ export interface Settings {
   tabSidebarSide: 'left' | 'right';
 }
 
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
 export const defaultSettings: Settings = {
+  general: {
+    userName: 'Friend',
+    searchEngine: 'google',
+    sidebarSide: 'right',
+    showGreeting: true,
+  },
+  clock: {
+    timeFormat: '12h',
+    showSeconds: false,
+    leadingZero: false,
+    style: 'default',
+    color: '#ffffff',
+    size: 120,
+    weight: 200,
+    showDate: false,
+    dateFormat: 'long',
+  },
+  background: {
+    source: 'local',
+    unsplashApiKey: '',
+    unsplashCollectionId: '',
+  },
+  weather: {
+    show: true,
+    unit: 'F',
+    location: '',
+    apiKey: '',
+  },
+  widgets: {
+    showLinks: true,
+    showFocus: true,
+    showQuotes: true,
+    quoteSource: 'local',
+    quickLinks: [
+      { name: 'Gmail', url: 'https://gmail.com', icon: '' },
+      { name: 'YouTube', url: 'https://youtube.com', icon: '' },
+      { name: 'GitHub', url: 'https://github.com', icon: '' },
+    ],
+  },
+  focus: {
+    mainFocus: '',
+    completed: false,
+  },
+  integrations: {
+    calendar: { days: 7 },
+    spotify: {},
+    finance: {
+      finnhubApiKey: '',
+      watchlistTickers: [],
+      cryptoWatchlist: [],
+      showStocks: false,
+      showCrypto: false,
+    },
+  },
+};
+
+export const defaultLegacySettings: LegacySettings = {
   userName: 'Friend',
   timeFormat: '12h',
   showSeconds: false,


### PR DESCRIPTION
## Summary

- Replaces flat 28-field `Settings` interface with a 7-section structure: `general`, `clock`, `background`, `weather`, `widgets`, `focus`, `integrations`
- Adds `LegacySettings` — exact mirror of the old flat interface, used only by the migration function (#77)
- Exports `SETTINGS_VERSION = 2`
- Drops `calendarConnected` / `spotifyConnected` — runtime OAuth state, not user preferences
- Removes `localBackground` from the sync type — it moves to `chrome.storage.local` in #83
- Adds `FinanceIntegration` scaffold for first-wave integrations
- Adds `defaultLegacySettings` alongside updated `defaultSettings`

## Build status

> ⚠️ CI will fail on this PR — consumers still reference flat field names (`settings.clockColor`, `settings.searchEngine`, etc.). This is expected. Each domain PR (#81–#87) migrates one section's consumers. The build will be green again after #89 (cleanup).

## Part of epic #91

Stack order: **#78** (this) → #77 → #79 → #80 → #81–#87 parallel → #88 → #89 → #90

Each PR targets the previous PR's branch. Merge in strict order once the final build is green.

## Test plan

- [ ] Verify `settings.ts` compiles in isolation (`tsc --noEmit src/types/settings.ts`)
- [ ] Verify all 7 section interfaces are exported
- [ ] Verify `LegacySettings` has all 28 original fields
- [ ] Verify `defaultSettings` compiles against new `Settings` type
- [ ] Verify `SETTINGS_VERSION = 2` is exported

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)