### PR TITLE
feat(backend): sectioned settings schema with deep-merge upsert

### DIFF
--- a/backend/src/controllers/settings.controller.ts
+++ b/backend/src/controllers/settings.controller.ts
@@ -5,54 +5,62 @@ import * as settingsService from '../services/settings.service.js';
 const quickLinkSchema = z.object({
   name: z.string().max(100),
   url: z.string().url().max(2048),
-  icon: z.string().max(2048),
+  icon: z.string().max(2048).optional(),
 });
 
-const settingsSchema = z.object({
-  userName: z.string().max(50),
-  theme: z.string().max(50),
-  language: z.string().max(10),
-  timeFormat: z.enum(['12h', '24h']),
-  showSeconds: z.boolean(),
-  clockLeadingZero: z.boolean(),
-  clockStyle: z.enum(['default', 'glass', 'outline']),
-  clockColor: z.string().max(50),
-  clockSize: z.number().int().min(20).max(500),
-  clockWeight: z.union([z.literal(100), z.literal(200), z.literal(400), z.literal(600)]),
-  showDate: z.boolean(),
-  dateFormat: z.enum(['long', 'short', 'numeric']),
-  temperatureUnit: z.enum(['F', 'C']),
-  backgroundSource: z.enum(['unsplash', 'local']),
-  unsplashApiKey: z.string().max(100),
-  unsplashCollectionId: z.string().max(100),
-  // Base64-encoded image: must start with a data URI for a supported image type.
-  // Capped at 600 KB (encoded) ≈ ~450 KB actual image to prevent storage exhaustion.
-  localBackground: z
-    .string()
-    .max(600_000)
-    .refine(
-      (v) => v === '' || /^data:image\/(jpeg|png|webp|gif);base64,/.test(v),
-      { message: 'localBackground must be a base64-encoded JPEG, PNG, WebP, or GIF data URI' },
-    ),
-  location: z.string().max(100),
-  weatherApiKey: z.string().max(100),
-  calendarConnected: z.boolean(),
-  calendarDays: z.union([z.literal(7), z.literal(14), z.literal(30)]),
-  spotifyConnected: z.boolean(),
-  quickLinks: z.array(quickLinkSchema),
-  quotesEnabled: z.boolean(),
-  quoteSource: z.enum(['local', 'api']),
-  mainFocus: z.string().max(200),
-  focusCompleted: z.boolean(),
-  showWeather: z.boolean(),
-  showLinks: z.boolean(),
-  showFocus: z.boolean(),
-  showGreeting: z.boolean(),
-  searchEngine: z.enum(['google', 'bing', 'duckduckgo', 'brave']),
-  tabSidebarSide: z.enum(['left', 'right']),
-  // Allow the sync timestamp sent by the client
+const settingsSectionSchema = z.object({
+  general: z.object({
+    userName: z.string().max(50),
+    searchEngine: z.enum(['google', 'bing', 'duckduckgo', 'brave']),
+    sidebarSide: z.enum(['left', 'right']),
+    showGreeting: z.boolean(),
+  }).partial().optional(),
+
+  clock: z.object({
+    timeFormat: z.enum(['12h', '24h']),
+    showSeconds: z.boolean(),
+    leadingZero: z.boolean(),
+    style: z.enum(['default', 'glass', 'outline']),
+    color: z.string().max(50),
+    size: z.number().int().min(20).max(500),
+    weight: z.union([z.literal(100), z.literal(200), z.literal(400), z.literal(600)]),
+    showDate: z.boolean(),
+    dateFormat: z.enum(['long', 'short', 'numeric']),
+  }).partial().optional(),
+
+  background: z.object({
+    source: z.enum(['unsplash', 'local']),
+    unsplashApiKey: z.string().max(100),
+    unsplashCollectionId: z.string().max(100),
+  }).partial().optional(),
+
+  weather: z.object({
+    show: z.boolean(),
+    unit: z.enum(['F', 'C']),
+    location: z.string().max(100),
+    apiKey: z.string().max(100),
+  }).partial().optional(),
+
+  widgets: z.object({
+    showLinks: z.boolean(),
+    showFocus: z.boolean(),
+    showQuotes: z.boolean(),
+    quoteSource: z.enum(['local', 'api']),
+    quickLinks: z.array(quickLinkSchema).max(50),
+  }).partial().optional(),
+
+  integrations: z.object({
+    calendar: z.object({
+      days: z.union([z.literal(7), z.literal(14), z.literal(30)]),
+      connected: z.boolean(),
+    }).partial().optional(),
+    spotify: z.object({
+      connected: z.boolean(),
+    }).partial().optional(),
+  }).partial().optional(),
+
   _updatedAt: z.number().optional(),
-}).partial();
+});
 
 export async function getSettingsController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const data = await settingsService.getSettings(req.user.sub);
@@ -60,14 +68,25 @@ export async function getSettingsController(req: FastifyRequest, reply: FastifyR
 }
 
 export async function putSettingsController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const result = settingsSchema.safeParse(req.body);
-  if (!result.success) {
-    void reply.status(400).send({
-      error: 'Invalid settings payload',
-      details: result.error.flatten().fieldErrors,
-    });
-    return;
+  const incoming = settingsSectionSchema.parse(req.body);
+
+  // Strip _updatedAt from stored data (sync metadata, not settings)
+  const { _updatedAt, ...incomingSections } = incoming;
+
+  const existing = (await settingsService.getSettings(req.user.sub)) ?? {};
+
+  const merged: Record<string, unknown> = { ...existing };
+  for (const [section, value] of Object.entries(incomingSections)) {
+    if (value !== undefined) {
+      merged[section] = {
+        ...(typeof existing[section] === 'object' && existing[section] !== null
+          ? (existing[section] as Record<string, unknown>)
+          : {}),
+        ...(value as Record<string, unknown>),
+      };
+    }
   }
-  const data = await settingsService.saveSettings(req.user.sub, result.data as Record<string, unknown>);
-  void reply.send({ data });
+
+  const saved = await settingsService.saveSettings(req.user.sub, merged);
+  void reply.send({ data: saved });
 }

--- a/backend/src/controllers/settings.controller.ts
+++ b/backend/src/controllers/settings.controller.ts
@@ -71,7 +71,8 @@ export async function putSettingsController(req: FastifyRequest, reply: FastifyR
   const incoming = settingsSectionSchema.parse(req.body);
 
   // Strip _updatedAt from stored data (sync metadata, not settings)
-  const { _updatedAt, ...incomingSections } = incoming;
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { _updatedAt: _, ...incomingSections } = incoming;
 
   const existing = (await settingsService.getSettings(req.user.sub)) ?? {};
 

--- a/backend/src/routes/__tests__/auth.routes.test.ts
+++ b/backend/src/routes/__tests__/auth.routes.test.ts
@@ -188,14 +188,14 @@ describe('settings', () => {
 
   it('PUT /settings saves and returns data', async () => {
     const { accessToken } = (await register('s2@s.com', 'password123', 'S2')).json<{ accessToken: string }>();
-    const payload = { theme: 'dark', language: 'en' };
+    const payload = { general: { userName: 'TestUser', showGreeting: true } };
 
     const putRes = await app.inject({ method: 'PUT', url: '/settings', headers: { Authorization: `Bearer ${accessToken}` }, payload });
     expect(putRes.statusCode).toBe(200);
-    expect(putRes.json<{ data: typeof payload }>().data).toEqual(payload);
+    expect(putRes.json<{ data: typeof payload }>().data).toMatchObject(payload);
 
     const getRes = await app.inject({ method: 'GET', url: '/settings', headers: { Authorization: `Bearer ${accessToken}` } });
-    expect(getRes.json<{ data: typeof payload }>().data).toEqual(payload);
+    expect(getRes.json<{ data: typeof payload }>().data).toMatchObject(payload);
   });
 });
 

--- a/backend/src/routes/__tests__/e2e.test.ts
+++ b/backend/src/routes/__tests__/e2e.test.ts
@@ -522,32 +522,34 @@ describe('Journey 5 - settings persistence and cross-user isolation', () => {
     expect(res.json<{ data: null }>().data).toBeNull();
   });
 
-  it('PUT then GET round-trips JSON data using valid settings fields', async () => {
+  it('PUT then GET round-trips JSON data using valid sectioned fields', async () => {
     const { accessToken } = await fullRegister();
-    const payload = { theme: 'dark', language: 'en', quotesEnabled: true };
+    const payload = { general: { showGreeting: true }, widgets: { showQuotes: true } };
 
     await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload });
     const res = await app.inject({ method: 'GET', url: '/settings', headers: authHeader(accessToken) });
-    expect(res.json<{ data: typeof payload }>().data).toEqual(payload);
+    expect(res.json<{ data: typeof payload }>().data).toMatchObject(payload);
   });
 
-  it('PUT overwrites previous settings completely', async () => {
+  it('PUT deep-merges sections without erasing unrelated sections', async () => {
     const { accessToken } = await fullRegister();
 
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { theme: 'dark', language: 'en' } });
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { userName: 'Override' } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { general: { userName: 'First' }, clock: { showSeconds: false } } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { general: { userName: 'Override' } } });
 
     const res = await app.inject({ method: 'GET', url: '/settings', headers: authHeader(accessToken) });
-    const data = res.json<{ data: Record<string, unknown> }>().data;
-    // Old keys gone after full overwrite
-    expect(data).toEqual({ userName: 'Override' });
+    const data = res.json<{ data: Record<string, Record<string, unknown>> }>().data;
+    // General section updated
+    expect(data?.general?.userName).toBe('Override');
+    // Clock section preserved from first PUT (deep-merge, not overwrite)
+    expect(data?.clock?.showSeconds).toBe(false);
   });
 
   it('user A settings are not visible to user B', async () => {
     const a = await fullRegister('a@e2e.test');
     const b = await fullRegister('b@e2e.test');
 
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(a.accessToken), payload: { userName: 'user-a-data' } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(a.accessToken), payload: { general: { userName: 'user-a-data' } } });
 
     const bRes = await app.inject({ method: 'GET', url: '/settings', headers: authHeader(b.accessToken) });
     expect(bRes.json<{ data: null }>().data).toBeNull();
@@ -555,25 +557,25 @@ describe('Journey 5 - settings persistence and cross-user isolation', () => {
 
   it('settings survive a logout + login cycle', async () => {
     const { accessToken: tok1, cookie } = await fullRegister();
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(tok1), payload: { spotifyConnected: true } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(tok1), payload: { integrations: { spotify: { connected: true } } } });
 
     // Logout then log back in
     await app.inject({ method: 'POST', url: '/auth/logout', cookies: { windom_refresh: cookie } });
     const newToken = (await login()).json<{ accessToken: string }>().accessToken;
 
     const res = await app.inject({ method: 'GET', url: '/settings', headers: authHeader(newToken) });
-    expect(res.json<{ data: { spotifyConnected: boolean } }>().data?.spotifyConnected).toBe(true);
+    expect(res.json<{ data: { integrations: { spotify: { connected: boolean } } } }>().data?.integrations?.spotify?.connected).toBe(true);
   });
 
   it('settings row is written to DB with correct userId', async () => {
     const { accessToken } = await fullRegister();
     const user = await getUserByEmail('user@e2e.test');
 
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { userName: 'val' } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { general: { userName: 'val' } } });
 
     const rows = await db.select().from(userSettings).where(eq(userSettings.userId, user.id));
     expect(rows).toHaveLength(1);
-    expect((rows[0].data as Record<string, string>)['userName']).toBe('val');
+    expect((rows[0].data as Record<string, Record<string, string>>)['general']['userName']).toBe('val');
   });
 });
 
@@ -587,7 +589,7 @@ describe('Journey 6 - account deletion', () => {
     const user = await getUserByEmail('user@e2e.test');
 
     // Create some related data
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { spotifyConnected: true } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { general: { userName: 'to-be-deleted' } } });
     await app.inject({ method: 'POST', url: '/auth/forgot-password', payload: { email: 'user@e2e.test' } });
 
     // Delete account
@@ -855,7 +857,7 @@ describe('Journey 10 - cross-service interactions', () => {
     const { accessToken } = await fullRegister();
 
     // Save settings
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { mainFocus: 'clock' } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(accessToken), payload: { general: { userName: 'persisted-name' } } });
 
     // Change password
     await app.inject({
@@ -866,7 +868,7 @@ describe('Journey 10 - cross-service interactions', () => {
     // Settings still there after re-login with new password
     const newToken = (await login('user@e2e.test', 'Updated456!')).json<{ accessToken: string }>().accessToken;
     const res = await app.inject({ method: 'GET', url: '/settings', headers: authHeader(newToken) });
-    expect(res.json<{ data: { mainFocus: string } }>().data?.mainFocus).toBe('clock');
+    expect(res.json<{ data: { general: { userName: string } } }>().data?.general?.userName).toBe('persisted-name');
   });
 
   it('OAuth accounts deleted when user account is deleted', async () => {
@@ -894,16 +896,16 @@ describe('Journey 10 - cross-service interactions', () => {
     const a = await fullRegister('a@same.test', 'Password123!', 'Alex');
     const b = await fullRegister('b@same.test', 'Password123!', 'Alex');
 
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(a.accessToken), payload: { mainFocus: 'focus-a' } });
-    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(b.accessToken), payload: { mainFocus: 'focus-b' } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(a.accessToken), payload: { general: { userName: 'focus-a' } } });
+    await app.inject({ method: 'PUT', url: '/settings', headers: authHeader(b.accessToken), payload: { general: { userName: 'focus-b' } } });
 
     const aSettings = (await app.inject({ method: 'GET', url: '/settings', headers: authHeader(a.accessToken) }))
-      .json<{ data: { mainFocus: string } }>().data;
+      .json<{ data: { general: { userName: string } } }>().data;
     const bSettings = (await app.inject({ method: 'GET', url: '/settings', headers: authHeader(b.accessToken) }))
-      .json<{ data: { mainFocus: string } }>().data;
+      .json<{ data: { general: { userName: string } } }>().data;
 
-    expect(aSettings?.mainFocus).toBe('focus-a');
-    expect(bSettings?.mainFocus).toBe('focus-b');
+    expect(aSettings?.general?.userName).toBe('focus-a');
+    expect(bSettings?.general?.userName).toBe('focus-b');
   });
 
   it('name update via PATCH /me persists in DB', async () => {


### PR DESCRIPTION
## Summary

- Replace the flat 30+ field Zod schema in the settings controller with a sectioned shape that mirrors the v2 `Settings` type from the extension
- PUT handler now deep-merges incoming sections into existing stored data, preventing one client from erasing another section's values on partial update
- `focus` section is intentionally excluded from the schema — it is device-local and must never be synced to the backend

## Issues closed

Closes #88

## Test plan

- [ ] `PUT /settings` with a partial sectioned body (e.g. `{ "clock": { "timeFormat": "24h" } }`) returns the merged document
- [ ] Two sequential partial updates each targeting different sections do not erase each other
- [ ] `focus` section is rejected / ignored if accidentally included in the request body

🤖 Generated with [Claude Code](https://claude.com/claude-code) by [Backend-Dev-Agent] [Claude-Bot] of [@Yehuda Briskman]