### PR TITLE
feat(extension): add onboarding flow, spotify notice, and guide panel

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -14,6 +14,8 @@
   <link rel="icon" type="image/png" sizes="16x16" href="icons/icon16.png" />
   <link rel="icon" type="image/png" sizes="48x48" href="icons/icon48.png" />
   <link rel="apple-touch-icon" href="icons/icon128.png" />
+  <!-- Apply stored language before paint to avoid flash -->
+  <script>(function(){var l=localStorage.getItem('guide-lang');if(l==='he')document.documentElement.lang='he';})();</script>
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
@@ -108,6 +110,7 @@
       gap: 8px;
       margin-top: 28px;
       flex-wrap: wrap;
+      align-items: center;
     }
 
     nav a {
@@ -124,6 +127,25 @@
       color: var(--accent);
       border-color: rgba(123,158,245,0.25);
       background: rgba(123,158,245,0.06);
+    }
+
+    button.lang-toggle {
+      font-family: inherit;
+      font-size: 0.85rem;
+      padding: 5px 14px;
+      border-radius: 999px;
+      border: 1px solid rgba(123,158,245,0.3);
+      background: rgba(123,158,245,0.1);
+      color: var(--accent);
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.2s ease, border-color 0.2s ease;
+      margin-left: auto;
+    }
+    html[lang="he"] button.lang-toggle { margin-left: 0; margin-right: auto; }
+    button.lang-toggle:hover {
+      background: rgba(123,158,245,0.18);
+      border-color: rgba(123,158,245,0.5);
     }
 
     /* ── TYPOGRAPHY ── */
@@ -162,6 +184,7 @@
 
     p { color: var(--muted); margin-bottom: 12px; font-size: 0.97rem; }
     ul, ol { color: var(--muted); padding-left: 22px; margin-bottom: 12px; font-size: 0.97rem; }
+    html[lang="he"] ul, html[lang="he"] ol { padding-left: 0; padding-right: 22px; }
     li { margin-bottom: 6px; }
     a { color: var(--accent); text-decoration: none; }
     a:hover { text-decoration: underline; }
@@ -236,6 +259,11 @@
       color: var(--muted);
       font-size: 0.93rem;
     }
+    html[lang="he"] .callout {
+      border-left: 1px solid rgba(123,158,245,0.15);
+      border-right: 3px solid var(--accent);
+      border-radius: 10px 0 0 10px;
+    }
     .callout strong { color: var(--text); }
 
     .callout.tip {
@@ -243,16 +271,19 @@
       border-color: rgba(92,184,92,0.15);
       border-left-color: var(--green);
     }
+    html[lang="he"] .callout.tip { border-right-color: var(--green); border-left-color: rgba(92,184,92,0.15); }
     .callout.warning {
       background: rgba(226,185,110,0.05);
       border-color: rgba(226,185,110,0.15);
       border-left-color: var(--amber);
     }
+    html[lang="he"] .callout.warning { border-right-color: var(--amber); border-left-color: rgba(226,185,110,0.15); }
     .callout.spotify {
       background: rgba(29,185,84,0.05);
       border-color: rgba(29,185,84,0.15);
       border-left-color: var(--spotify);
     }
+    html[lang="he"] .callout.spotify { border-right-color: var(--spotify); border-left-color: rgba(29,185,84,0.15); }
 
     /* ── STEPS ── */
     .step {
@@ -427,6 +458,19 @@
       animation-range: 10% 90%;
     }
     @keyframes path-draw-2 { to { stroke-dashoffset: 0; } }
+
+    /* ── LANGUAGE TOGGLE ── */
+    html[lang="he"] { direction: rtl; }
+
+    /* Inline language spans */
+    .l.he { display: none; }
+    html[lang="he"] .l.en { display: none; }
+    html[lang="he"] span.l.he { display: inline; }
+
+    /* Block language divs */
+    div.l.he { display: none; }
+    html[lang="he"] div.l.en { display: none; }
+    html[lang="he"] div.l.he { display: block; }
   </style>
 </head>
 <body>
@@ -457,20 +501,21 @@
       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
         <path d="M10 12L6 8l4-4"/>
       </svg>
-      Back to home
+      <span class="l en">Back to home</span><span class="l he">חזרה לדף הבית</span>
     </a>
-    <div class="header-badge">User Guide</div>
-    <h1>How to use WindoM</h1>
-    <p>Everything in one place — from connecting Spotify to customizing your clock.</p>
+    <div class="header-badge"><span class="l en">User Guide</span><span class="l he">מדריך למשתמש</span></div>
+    <h1><span class="l en">How to use WindoM</span><span class="l he">איך להשתמש ב-WindoM</span></h1>
+    <p><span class="l en">Everything in one place — from connecting Spotify to customizing your clock.</span><span class="l he">הכל במקום אחד — מחיבור ספוטיפיי ועד התאמה אישית של השעון שלך.</span></p>
     <nav>
-      <a href="#account">Account</a>
-      <a href="#spotify">Spotify</a>
-      <a href="#calendar">Calendar</a>
-      <a href="#focus">Focus Timer</a>
-      <a href="#background">Background</a>
-      <a href="#weather">Weather</a>
-      <a href="#links">Quick Links</a>
-      <a href="#clock">Clock</a>
+      <a href="#account"><span class="l en">Account</span><span class="l he">חשבון</span></a>
+      <a href="#spotify"><span class="l en">Spotify</span><span class="l he">ספוטיפיי</span></a>
+      <a href="#calendar"><span class="l en">Calendar</span><span class="l he">לוח שנה</span></a>
+      <a href="#focus"><span class="l en">Focus Timer</span><span class="l he">טיימר פוקוס</span></a>
+      <a href="#background"><span class="l en">Background</span><span class="l he">רקע</span></a>
+      <a href="#weather"><span class="l en">Weather</span><span class="l he">מזג אוויר</span></a>
+      <a href="#links"><span class="l en">Quick Links</span><span class="l he">קישורים מהירים</span></a>
+      <a href="#clock"><span class="l en">Clock</span><span class="l he">שעון</span></a>
+      <button class="lang-toggle" id="lang-btn">עברית</button>
     </nav>
   </header>
 
@@ -480,43 +525,43 @@
   ───────────────────────────────────────────────── -->
 
   <div class="callout tip">
-    <strong>No account required for most things.</strong>
-    Clock, weather, todos, backgrounds, quotes, quick links, and the focus timer all work instantly with no sign-in.
-    An account is only needed for Google Calendar sync and Spotify. You can always add one later.
+    <strong><span class="l en">No account required for most things.</span><span class="l he">רוב הפונקציות לא דורשות חשבון.</span></strong>
+    <span class="l en">Clock, weather, todos, backgrounds, quotes, quick links, and the focus timer all work instantly with no sign-in. An account is only needed for Google Calendar sync and Spotify. You can always add one later.</span>
+    <span class="l he">שעון, מזג אוויר, משימות, רקעים, ציטוטים, קישורים מהירים וטיימר הפוקוס עובדים מיד ללא התחברות. חשבון נדרש רק לסנכרון Google Calendar ו-Spotify. תמיד אפשר להוסיף אחד מאוחר יותר.</span>
   </div>
 
   <div class="feature-grid">
     <div class="feature-card">
-      <div class="feature-card-title">🕐 Clock &amp; Date</div>
-      <div class="feature-card-desc">12h / 24h, custom color, font size, date format. Always on, no account needed.</div>
+      <div class="feature-card-title">🕐 <span class="l en">Clock &amp; Date</span><span class="l he">שעון ותאריך</span></div>
+      <div class="feature-card-desc"><span class="l en">12h / 24h, custom color, font size, date format. Always on, no account needed.</span><span class="l he">12/24 שעות, צבע מותאם, גודל גופן, פורמט תאריך. תמיד פעיל, ללא חשבון.</span></div>
     </div>
     <div class="feature-card">
-      <div class="feature-card-title">🌤 Weather</div>
-      <div class="feature-card-desc">Live temperature and conditions. Needs a free OpenWeatherMap API key.</div>
+      <div class="feature-card-title">🌤 <span class="l en">Weather</span><span class="l he">מזג אוויר</span></div>
+      <div class="feature-card-desc"><span class="l en">Live temperature and conditions. Needs a free OpenWeatherMap API key.</span><span class="l he">טמפרטורה ומצב מזג אוויר בזמן אמת. דורש מפתח API חינמי מ-OpenWeatherMap.</span></div>
     </div>
     <div class="feature-card">
-      <div class="feature-card-title">🖼 Background</div>
-      <div class="feature-card-desc">Rotating Unsplash photos or upload your own image. Stored locally.</div>
+      <div class="feature-card-title">🖼 <span class="l en">Background</span><span class="l he">רקע</span></div>
+      <div class="feature-card-desc"><span class="l en">Rotating Unsplash photos or upload your own image. Stored locally.</span><span class="l he">תמונות מתחלפות מ-Unsplash או העלה תמונה משלך. מאוחסן מקומית.</span></div>
     </div>
     <div class="feature-card">
-      <div class="feature-card-title">⏱ Focus Timer</div>
-      <div class="feature-card-desc">Set an intention and dim everything else. No account needed.</div>
+      <div class="feature-card-title">⏱ <span class="l en">Focus Timer</span><span class="l he">טיימר פוקוס</span></div>
+      <div class="feature-card-desc"><span class="l en">Set an intention and dim everything else. No account needed.</span><span class="l he">הגדר כוונה ועמעם את כל השאר. ללא חשבון.</span></div>
     </div>
     <div class="feature-card">
-      <div class="feature-card-title">🔗 Quick Links</div>
-      <div class="feature-card-desc">Pin your most-used sites to the dock bar at the top.</div>
+      <div class="feature-card-title">🔗 <span class="l en">Quick Links</span><span class="l he">קישורים מהירים</span></div>
+      <div class="feature-card-desc"><span class="l en">Pin your most-used sites to the dock bar at the top.</span><span class="l he">נעץ את האתרים הנפוצים ביותר לסרגל הדוק בחלק העליון.</span></div>
     </div>
     <div class="feature-card">
-      <div class="feature-card-title">📋 Todos</div>
-      <div class="feature-card-desc">Local task list in the right sidebar. Stays on your device.</div>
+      <div class="feature-card-title">📋 <span class="l en">Todos</span><span class="l he">משימות</span></div>
+      <div class="feature-card-desc"><span class="l en">Local task list in the right sidebar. Stays on your device.</span><span class="l he">רשימת משימות מקומית בסרגל הצד הימני. נשמר במכשיר שלך.</span></div>
     </div>
     <div class="feature-card">
-      <div class="feature-card-title">🎵 Spotify</div>
-      <div class="feature-card-desc">Now-playing in the top dock. Needs an account + a free Spotify Developer app.</div>
+      <div class="feature-card-title">🎵 <span class="l en">Spotify</span><span class="l he">ספוטיפיי</span></div>
+      <div class="feature-card-desc"><span class="l en">Now-playing in the top dock. Needs an account + a free Spotify Developer app.</span><span class="l he">השיר הנוכחי בדוק העליון. דורש חשבון + אפליקציית Spotify Developer חינמית.</span></div>
     </div>
     <div class="feature-card">
       <div class="feature-card-title">📅 Google Calendar</div>
-      <div class="feature-card-desc">Upcoming events in the right sidebar. Needs an account + Google authorization.</div>
+      <div class="feature-card-desc"><span class="l en">Upcoming events in the right sidebar. Needs an account + Google authorization.</span><span class="l he">אירועים קרובים בסרגל הצד הימני. דורש חשבון + אישור Google.</span></div>
     </div>
   </div>
 
@@ -527,39 +572,47 @@
 
   <h2 id="account">
     <span class="section-icon" style="background:rgba(123,158,245,0.1);">👤</span>
-    Create a WindoM Account
+    <span class="l en">Create a WindoM Account</span><span class="l he">יצירת חשבון WindoM</span>
     <span class="badge optional">Optional</span>
   </h2>
 
   <p>
-    A WindoM account syncs your settings across devices and is required to connect Google Calendar or Spotify.
-    Registration is free and takes under a minute.
+    <span class="l en">A WindoM account syncs your settings across devices and is required to connect Google Calendar or Spotify. Registration is free and takes under a minute.</span>
+    <span class="l he">חשבון WindoM מסנכרן את ההגדרות שלך בין מכשירים ונדרש לחיבור Google Calendar או Spotify. ההרשמה חינמית ולוקחת פחות מדקה.</span>
   </p>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Open the gear icon (<strong>Settings</strong>) in the bottom-left corner of your new tab, then go to the <strong>Account</strong> tab.</p>
+      <p><span class="l en">Open the gear icon (<strong>Settings</strong>) in the bottom-left corner of your new tab, then go to the <strong>Account</strong> tab.</span><span class="l he">פתח את אייקון הגלגל שיניים (<strong>הגדרות</strong>) בפינה השמאלית התחתונה של לשונית החדשה, ועבור ללשונית <strong>חשבון</strong>.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>Enter your email address and a password (minimum 8 characters) and click <strong>Create account</strong>.</p>
-      <p>Or click <strong>Continue with Google</strong> if you prefer not to manage a password.</p>
+      <div class="l en">
+        <p>Enter your email address and a password (minimum 8 characters) and click <strong>Create account</strong>.</p>
+        <p>Or click <strong>Continue with Google</strong> if you prefer not to manage a password.</p>
+      </div>
+      <div class="l he">
+        <p>הכנס את כתובת האימייל שלך וסיסמה (לפחות 8 תווים) ולחץ על <strong>צור חשבון</strong>.</p>
+        <p>לחלופין, לחץ על <strong>המשך עם Google</strong> אם אינך רוצה לנהל סיסמה.</p>
+      </div>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>Check your inbox for a verification email and click the link inside. You're signed in.</p>
+      <p><span class="l en">Check your inbox for a verification email and click the link inside. You're signed in.</span><span class="l he">בדוק את תיבת הדואר שלך לאימות האימייל ולחץ על הקישור בתוכו. אתה מחובר.</span></p>
     </div>
   </div>
 
   <div class="callout tip">
-    <strong>Settings sync</strong> — once signed in, your clock format, background preference, widgets, and quick links all sync to the cloud and appear on any device where you're logged in to WindoM.
+    <strong><span class="l en">Settings sync</span><span class="l he">סנכרון הגדרות</span></strong> —
+    <span class="l en">once signed in, your clock format, background preference, widgets, and quick links all sync to the cloud and appear on any device where you're logged in to WindoM.</span>
+    <span class="l he">לאחר התחברות, פורמט השעון, הרקע המועדף, הווידג'טים והקישורים המהירים שלך מסתנכרנים לענן ומופיעים בכל מכשיר שבו אתה מחובר ל-WindoM.</span>
   </div>
 
 
@@ -569,134 +622,166 @@
 
   <h2 id="spotify">
     <span class="section-icon" style="background:rgba(29,185,84,0.12);">🎵</span>
-    Connect Spotify
+    <span class="l en">Connect Spotify</span><span class="l he">חיבור ספוטיפיי</span>
     <span class="badge byoa">BYOA</span>
   </h2>
 
   <p>
-    WindoM shows your Spotify now-playing card directly in the new tab dock.
-    Because of how Spotify's API works, each user connects their own free Spotify Developer app —
-    this keeps your account private and avoids any shared rate limits.
-    The whole setup takes about 2 minutes.
+    <span class="l en">WindoM shows your Spotify now-playing card directly in the new tab dock. Because of how Spotify's API works, each user connects their own free Spotify Developer app — this keeps your account private and avoids any shared rate limits. The whole setup takes about 2 minutes.</span>
+    <span class="l he">WindoM מציג את כרטיס השיר הנוכחי של ספוטיפיי ישירות בדוק לשונית החדשה. בגלל אופן פעולת ה-API של ספוטיפיי, כל משתמש מחבר את אפליקציית Spotify Developer החינמית שלו — זה שומר על פרטיות החשבון שלך ומונע הגבלות קצב משותפות. ההגדרה הכוללת לוקחת כ-2 דקות.</span>
   </p>
 
   <div class="callout spotify">
-    <strong>Why do I need my own app?</strong><br>
-    Spotify's Web API requires an OAuth app registered in their developer portal.
-    Instead of routing everyone through a shared WindoM app (which has quota limits and privacy implications),
-    each user creates their own free app — you get full control and there are no limits to worry about.
+    <strong><span class="l en">Why do I need my own app?</span><span class="l he">למה אני צריך אפליקציה משלי?</span></strong><br>
+    <span class="l en">Spotify's Web API requires an OAuth app registered in their developer portal. Instead of routing everyone through a shared WindoM app (which has quota limits and privacy implications), each user creates their own free app — you get full control and there are no limits to worry about.</span>
+    <span class="l he">ה-Web API של ספוטיפיי דורש אפליקציית OAuth רשומה בפורטל המפתחים שלהם. במקום לנתב את כולם דרך אפליקציית WindoM משותפת (שיש לה מגבלות מכסה והשלכות פרטיות), כל משתמש יוצר אפליקציה חינמית משלו — קיבלת שליטה מלאה ואין מגבלות לדאוג להן.</span>
   </div>
 
-  <h3>Before you start</h3>
+  <h3><span class="l en">Before you start</span><span class="l he">לפני שמתחילים</span></h3>
   <ul>
-    <li>You need a WindoM account (see above — free, takes 1 minute)</li>
-    <li>You need a Spotify account (free or premium both work)</li>
+    <li><span class="l en">You need a WindoM account (see above — free, takes 1 minute)</span><span class="l he">אתה צריך חשבון WindoM (ראה למעלה — חינמי, לוקח דקה)</span></li>
+    <li><span class="l en">You need a Spotify account (free or premium both work)</span><span class="l he">אתה צריך חשבון Spotify (חינמי או פרימיום — שניהם עובדים)</span></li>
   </ul>
 
-  <h3>Step 1 — Create a Spotify Developer app</h3>
+  <h3><span class="l en">Step 1 — Create a Spotify Developer app</span><span class="l he">שלב 1 — יצירת אפליקציית Spotify Developer</span></h3>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Go to <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">developer.spotify.com/dashboard</a> and log in with your Spotify account.</p>
+      <p><span class="l en">Go to <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">developer.spotify.com/dashboard</a> and log in with your Spotify account.</span><span class="l he">עבור אל <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">developer.spotify.com/dashboard</a> והתחבר עם חשבון ספוטיפיי שלך.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>Click <strong>Create app</strong>.</p>
-      <ul>
-        <li><strong>App name</strong> — anything you like, e.g. <em>My WindoM</em></li>
-        <li><strong>App description</strong> — anything, e.g. <em>Personal WindoM integration</em></li>
-        <li><strong>Redirect URI</strong> — leave this empty for now, you'll add it in Step 2</li>
-        <li><strong>Which API/SDKs are you planning to use?</strong> — select <strong>Web API</strong></li>
-      </ul>
-      <p>Agree to the terms and click <strong>Save</strong>.</p>
+      <div class="l en">
+        <p>Click <strong>Create app</strong>.</p>
+        <ul>
+          <li><strong>App name</strong> — anything you like, e.g. <em>My WindoM</em></li>
+          <li><strong>App description</strong> — anything, e.g. <em>Personal WindoM integration</em></li>
+          <li><strong>Redirect URI</strong> — leave this empty for now, you'll add it in Step 2</li>
+          <li><strong>Which API/SDKs are you planning to use?</strong> — select <strong>Web API</strong></li>
+        </ul>
+        <p>Agree to the terms and click <strong>Save</strong>.</p>
+      </div>
+      <div class="l he">
+        <p>לחץ על <strong>Create app</strong>.</p>
+        <ul>
+          <li><strong>App name</strong> — כל שם שתרצה, למשל <em>My WindoM</em></li>
+          <li><strong>App description</strong> — כל דבר, למשל <em>Personal WindoM integration</em></li>
+          <li><strong>Redirect URI</strong> — השאר ריק לעת עתה, תוסיף אותו בשלב 2</li>
+          <li><strong>Which API/SDKs are you planning to use?</strong> — בחר <strong>Web API</strong></li>
+        </ul>
+        <p>הסכם לתנאים ולחץ על <strong>Save</strong>.</p>
+      </div>
     </div>
   </div>
 
-  <h3>Step 2 — Copy your Redirect URI from WindoM</h3>
+  <h3><span class="l en">Step 2 — Copy your Redirect URI from WindoM</span><span class="l he">שלב 2 — העתק את ה-Redirect URI מ-WindoM</span></h3>
 
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>
-        Open your WindoM new tab, click <strong>Settings</strong> (gear icon, bottom-left), then go to the <strong>Spotify</strong> tab.
-      </p>
-      <p>
-        You'll see a box labelled <strong>Redirect URI</strong> with a value that looks like this:
-      </p>
-      <div class="redirect-uri-box">
-        <span class="redirect-uri-label">Redirect URI</span>
-        <span class="redirect-uri-value">https://&lt;your-extension-id&gt;.chromiumapp.org/</span>
+      <div class="l en">
+        <p>
+          Open your WindoM new tab, click <strong>Settings</strong> (gear icon, bottom-left), then go to the <strong>Spotify</strong> tab.
+        </p>
+        <p>
+          You'll see a box labelled <strong>Redirect URI</strong> with a value that looks like this:
+        </p>
+        <div class="redirect-uri-box">
+          <span class="redirect-uri-label">Redirect URI</span>
+          <span class="redirect-uri-value">https://&lt;your-extension-id&gt;.chromiumapp.org/</span>
+        </div>
+        <p>Click the <strong>Copy</strong> button next to it. This URI is unique to your Chrome installation — do not type it manually.</p>
       </div>
-      <p>Click the <strong>Copy</strong> button next to it. This URI is unique to your Chrome installation — do not type it manually.</p>
+      <div class="l he">
+        <p>
+          פתח את לשונית WindoM החדשה, לחץ על <strong>הגדרות</strong> (אייקון גלגל שיניים, שמאל תחתון), ועבור ללשונית <strong>ספוטיפיי</strong>.
+        </p>
+        <p>
+          תראה תיבה עם התווית <strong>Redirect URI</strong> עם ערך שנראה כך:
+        </p>
+        <div class="redirect-uri-box">
+          <span class="redirect-uri-label">Redirect URI</span>
+          <span class="redirect-uri-value">https://&lt;your-extension-id&gt;.chromiumapp.org/</span>
+        </div>
+        <p>לחץ על כפתור <strong>העתק</strong> לידו. URI זה ייחודי להתקנת Chrome שלך — אל תקליד אותו ידנית.</p>
+      </div>
     </div>
   </div>
 
-  <h3>Step 3 — Add the Redirect URI to your Spotify app</h3>
+  <h3><span class="l en">Step 3 — Add the Redirect URI to your Spotify app</span><span class="l he">שלב 3 — הוסף את ה-Redirect URI לאפליקציית ספוטיפיי שלך</span></h3>
 
   <div class="step">
     <div class="step-num">4</div>
     <div class="step-body">
-      <p>Go back to the <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">Spotify Developer Dashboard</a>, click on your app, then click <strong>Settings</strong> (top right of your app page).</p>
+      <p><span class="l en">Go back to the <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">Spotify Developer Dashboard</a>, click on your app, then click <strong>Settings</strong> (top right of your app page).</span><span class="l he">חזור אל <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">Spotify Developer Dashboard</a>, לחץ על האפליקציה שלך, ואז לחץ על <strong>Settings</strong> (למעלה ימין בדף האפליקציה שלך).</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">5</div>
     <div class="step-body">
-      <p>Scroll to the <strong>Redirect URIs</strong> field. Paste the URI you copied from WindoM, then click <strong>Add</strong>, then <strong>Save</strong> at the bottom.</p>
+      <p><span class="l en">Scroll to the <strong>Redirect URIs</strong> field. Paste the URI you copied from WindoM, then click <strong>Add</strong>, then <strong>Save</strong> at the bottom.</span><span class="l he">גלול לשדה <strong>Redirect URIs</strong>. הדבק את ה-URI שהעתקת מ-WindoM, לחץ על <strong>Add</strong>, ואז על <strong>Save</strong> בתחתית.</span></p>
     </div>
   </div>
 
   <div class="callout warning">
-    <strong>This step is easy to miss.</strong>
-    If you skip adding the Redirect URI you'll get an <em>Invalid Client</em> error when you try to connect.
-    The URI must match exactly — copy it using the button in WindoM, don't type it by hand.
+    <strong><span class="l en">This step is easy to miss.</span><span class="l he">שלב זה קל לפספס.</span></strong>
+    <span class="l en">If you skip adding the Redirect URI you'll get an <em>Invalid Client</em> error when you try to connect. The URI must match exactly — copy it using the button in WindoM, don't type it by hand.</span>
+    <span class="l he">אם תדלג על הוספת ה-Redirect URI תקבל שגיאת <em>Invalid Client</em> בעת ניסיון החיבור. ה-URI חייב להתאים בדיוק — העתק אותו בעזרת הכפתור ב-WindoM, אל תקליד אותו ידנית.</span>
   </div>
 
-  <h3>Step 4 — Copy your Client ID and connect</h3>
+  <h3><span class="l en">Step 4 — Copy your Client ID and connect</span><span class="l he">שלב 4 — העתק את ה-Client ID והתחבר</span></h3>
 
   <div class="step">
     <div class="step-num">6</div>
     <div class="step-body">
-      <p>Still on your Spotify app's Settings page, copy the <strong>Client ID</strong> at the top. It looks like a 32-character hex string, e.g. <code>b3d9a1f0c84e...</code></p>
+      <p><span class="l en">Still on your Spotify app's Settings page, copy the <strong>Client ID</strong> at the top. It looks like a 32-character hex string, e.g. <code>b3d9a1f0c84e...</code></span><span class="l he">עדיין בדף ה-Settings של אפליקציית ספוטיפיי שלך, העתק את ה-<strong>Client ID</strong> בחלק העליון. הוא נראה כמחרוזת hex בת 32 תווים, למשל <code>b3d9a1f0c84e...</code></span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">7</div>
     <div class="step-body">
-      <p>Go back to WindoM → Settings → <strong>Spotify</strong> tab. Paste the Client ID into the input field and click <strong>Save &amp; Connect</strong>.</p>
+      <p><span class="l en">Go back to WindoM → Settings → <strong>Spotify</strong> tab. Paste the Client ID into the input field and click <strong>Save &amp; Connect</strong>.</span><span class="l he">חזור ל-WindoM → הגדרות → לשונית <strong>ספוטיפיי</strong>. הדבק את ה-Client ID בשדה הקלט ולחץ על <strong>שמור והתחבר</strong>.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">8</div>
     <div class="step-body">
-      <p>A Spotify authorization popup will appear. Click <strong>Agree</strong>.</p>
-      <p>You're connected. The now-playing card will appear in the top dock the next time you play a track.</p>
+      <div class="l en">
+        <p>A Spotify authorization popup will appear. Click <strong>Agree</strong>.</p>
+        <p>You're connected. The now-playing card will appear in the top dock the next time you play a track.</p>
+      </div>
+      <div class="l he">
+        <p>יופיע חלון קופץ לאישור ספוטיפיי. לחץ על <strong>Agree</strong>.</p>
+        <p>אתה מחובר. כרטיס השיר הנוכחי יופיע בדוק העליון בפעם הבאה שתנגן שיר.</p>
+      </div>
     </div>
   </div>
 
-  <h3>Troubleshooting</h3>
+  <h3><span class="l en">Troubleshooting</span><span class="l he">פתרון בעיות</span></h3>
 
   <div class="callout">
-    <strong>Error: Invalid Client</strong> — the Client ID is wrong or the Redirect URI wasn't saved correctly in the Spotify dashboard.
-    Double-check both. The Redirect URI must be copied from WindoM's Spotify tab, not typed manually.
+    <strong><span class="l en">Error: Invalid Client</span><span class="l he">שגיאה: Invalid Client</span></strong> —
+    <span class="l en">the Client ID is wrong or the Redirect URI wasn't saved correctly in the Spotify dashboard. Double-check both. The Redirect URI must be copied from WindoM's Spotify tab, not typed manually.</span>
+    <span class="l he">ה-Client ID שגוי או ה-Redirect URI לא נשמר כהלכה ב-Spotify dashboard. בדוק את שניהם שוב. יש להעתיק את ה-Redirect URI מלשונית ספוטיפיי של WindoM, לא להקליד ידנית.</span>
   </div>
 
   <div class="callout">
-    <strong>Error: Connection cancelled</strong> — you closed the Spotify popup before completing authorization.
-    Click Save &amp; Connect again and complete the authorization flow.
+    <strong><span class="l en">Error: Connection cancelled</span><span class="l he">שגיאה: חיבור בוטל</span></strong> —
+    <span class="l en">you closed the Spotify popup before completing authorization. Click Save &amp; Connect again and complete the authorization flow.</span>
+    <span class="l he">סגרת את חלון ספוטיפיי לפני השלמת האישור. לחץ שוב על שמור והתחבר והשלם את תהליך האישור.</span>
   </div>
 
   <div class="callout tip">
-    <strong>Changed Chrome profile or reinstalled Chrome?</strong>
-    Your Redirect URI will be different. Go to Settings → Spotify tab to see the new URI,
-    add it to your Spotify app settings (you can have multiple Redirect URIs), then reconnect.
+    <strong><span class="l en">Changed Chrome profile or reinstalled Chrome?</span><span class="l he">שינית פרופיל Chrome או התקנת מחדש?</span></strong>
+    <span class="l en">Your Redirect URI will be different. Go to Settings → Spotify tab to see the new URI, add it to your Spotify app settings (you can have multiple Redirect URIs), then reconnect.</span>
+    <span class="l he">ה-Redirect URI שלך יהיה שונה. עבור להגדרות → לשונית ספוטיפיי כדי לראות את ה-URI החדש, הוסף אותו להגדרות אפליקציית ספוטיפיי שלך (ניתן להוסיף מספר Redirect URIs), ואז התחבר מחדש.</span>
   </div>
 
 
@@ -706,46 +791,53 @@
 
   <h2 id="calendar">
     <span class="section-icon" style="background:rgba(66,133,244,0.12);">📅</span>
-    Connect Google Calendar
+    <span class="l en">Connect Google Calendar</span><span class="l he">חיבור Google Calendar</span>
   </h2>
 
   <p>
-    WindoM pulls your upcoming Google Calendar events into the right sidebar so your day is always visible.
-    This requires a WindoM account and a one-time Google authorization.
+    <span class="l en">WindoM pulls your upcoming Google Calendar events into the right sidebar so your day is always visible. This requires a WindoM account and a one-time Google authorization.</span>
+    <span class="l he">WindoM מציג את אירועי Google Calendar הקרובים שלך בסרגל הצד הימני כך שהיום שלך תמיד גלוי. זה דורש חשבון WindoM ואישור Google חד-פעמי.</span>
   </p>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Make sure you have a WindoM account and are signed in (Settings → Account tab).</p>
+      <p><span class="l en">Make sure you have a WindoM account and are signed in (Settings → Account tab).</span><span class="l he">ודא שיש לך חשבון WindoM ואתה מחובר (הגדרות → לשונית חשבון).</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>In the Account tab, scroll to <strong>Connected Services</strong>. Click <strong>Connect</strong> on the Google Calendar card.</p>
+      <p><span class="l en">In the Account tab, scroll to <strong>Connected Services</strong>. Click <strong>Connect</strong> on the Google Calendar card.</span><span class="l he">בלשונית חשבון, גלול ל<strong>שירותים מחוברים</strong>. לחץ על <strong>חבר</strong> בכרטיס Google Calendar.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>A Google authorization window opens. Choose your Google account and click <strong>Allow</strong>.</p>
-      <p>WindoM only requests read-only access to your calendar events — it cannot create, edit, or delete anything.</p>
+      <div class="l en">
+        <p>A Google authorization window opens. Choose your Google account and click <strong>Allow</strong>.</p>
+        <p>WindoM only requests read-only access to your calendar events — it cannot create, edit, or delete anything.</p>
+      </div>
+      <div class="l he">
+        <p>יפתח חלון אישור של Google. בחר את חשבון Google שלך ולחץ על <strong>Allow</strong>.</p>
+        <p>WindoM מבקש גישת קריאה בלבד לאירועי הלוח שנה שלך — הוא לא יכול ליצור, לערוך או למחוק דבר.</p>
+      </div>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">4</div>
     <div class="step-body">
-      <p>Done. Your upcoming events appear in the right sidebar, grouped by day.</p>
+      <p><span class="l en">Done. Your upcoming events appear in the right sidebar, grouped by day.</span><span class="l he">סיימת. האירועים הקרובים שלך מופיעים בסרגל הצד הימני, מקובצים לפי יום.</span></p>
     </div>
   </div>
 
   <div class="callout tip">
-    <strong>Look-ahead window</strong> — by default events for the next 7 days are shown.
-    You can change this to 14 or 30 days in Settings → <strong>Calendar</strong>.
+    <strong><span class="l en">Look-ahead window</span><span class="l he">חלון מראש</span></strong> —
+    <span class="l en">by default events for the next 7 days are shown. You can change this to 14 or 30 days in Settings → <strong>Calendar</strong>.</span>
+    <span class="l he">כברירת מחדל מוצגים אירועים ל-7 הימים הבאים. ניתן לשנות זאת ל-14 או 30 יום בהגדרות → <strong>לוח שנה</strong>.</span>
   </div>
 
 
@@ -755,37 +847,39 @@
 
   <h2 id="focus">
     <span class="section-icon" style="background:rgba(167,139,250,0.12);">⏱</span>
-    Focus Timer
+    <span class="l en">Focus Timer</span><span class="l he">טיימר פוקוס</span>
   </h2>
 
   <p>
-    The focus timer lets you set an intention for your session.
-    While active, the background dims and all other UI fades away so nothing distracts you.
+    <span class="l en">The focus timer lets you set an intention for your session. While active, the background dims and all other UI fades away so nothing distracts you.</span>
+    <span class="l he">טיימר הפוקוס מאפשר לך להגדיר כוונה לסשן שלך. כשהוא פעיל, הרקע מתעמעם וכל ממשק אחר נעלם כדי שלא יהיו הסחות דעת.</span>
   </p>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Click the focus input in the center of your new tab — it says something like <em>"What are you working on?"</em></p>
+      <p><span class="l en">Click the focus input in the center of your new tab — it says something like <em>"What are you working on?"</em></span><span class="l he">לחץ על שדה הפוקוס במרכז לשונית החדשה שלך — הוא אומר משהו כמו <em>"על מה אתה עובד?"</em></span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>Type what you're working on and press <strong>Enter</strong>. The timer starts and the tab dims.</p>
+      <p><span class="l en">Type what you're working on and press <strong>Enter</strong>. The timer starts and the tab dims.</span><span class="l he">הקלד על מה אתה עובד ולחץ על <strong>Enter</strong>. הטיימר מתחיל והלשונית מתעמעמת.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>When you're done, click anywhere on the screen or press <strong>Escape</strong> to exit focus mode.</p>
+      <p><span class="l en">When you're done, click anywhere on the screen or press <strong>Escape</strong> to exit focus mode.</span><span class="l he">כשתסיים, לחץ בכל מקום על המסך או לחץ על <strong>Escape</strong> כדי לצאת ממצב פוקוס.</span></p>
     </div>
   </div>
 
   <div class="callout tip">
-    <strong>Focus presets</strong> — go to Settings → <strong>Focus</strong> to save your most common focus tasks as one-click presets, so you don't have to type the same thing every day.
+    <strong><span class="l en">Focus presets</span><span class="l he">הגדרות מוקדמות לפוקוס</span></strong> —
+    <span class="l en">go to Settings → <strong>Focus</strong> to save your most common focus tasks as one-click presets, so you don't have to type the same thing every day.</span>
+    <span class="l he">עבור להגדרות → <strong>פוקוס</strong> כדי לשמור את משימות הפוקוס הנפוצות ביותר שלך כבחירה מהירה, כך שלא תצטרך להקליד כל יום מחדש.</span>
   </div>
 
 
@@ -795,54 +889,65 @@
 
   <h2 id="background">
     <span class="section-icon" style="background:rgba(245,158,11,0.12);">🖼</span>
-    Change Your Background
+    <span class="l en">Change Your Background</span><span class="l he">שינוי הרקע</span>
   </h2>
 
   <p>
-    WindoM supports two background sources: curated photos from Unsplash, or an image you upload from your device.
+    <span class="l en">WindoM supports two background sources: curated photos from Unsplash, or an image you upload from your device.</span>
+    <span class="l he">WindoM תומך בשני מקורות רקע: תמונות נבחרות מ-Unsplash, או תמונה שאתה מעלה מהמכשיר שלך.</span>
   </p>
 
-  <h3>Option A — Unsplash photos</h3>
+  <h3><span class="l en">Option A — Unsplash photos</span><span class="l he">אפשרות א — תמונות Unsplash</span></h3>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Open Settings → <strong>Background</strong> tab. Select <strong>Unsplash</strong>.</p>
+      <p><span class="l en">Open Settings → <strong>Background</strong> tab. Select <strong>Unsplash</strong>.</span><span class="l he">פתח הגדרות → לשונית <strong>רקע</strong>. בחר <strong>Unsplash</strong>.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>
-        Optionally, paste a <strong>Collection ID</strong> from Unsplash to curate the photo style.
-        To find a collection ID: go to <a href="https://unsplash.com/collections" target="_blank" rel="noreferrer">unsplash.com/collections</a>,
-        open any collection, and copy the number from the URL —
-        e.g. <code>unsplash.com/collections/<strong>4324303</strong>/...</code>
-      </p>
+      <div class="l en">
+        <p>
+          Optionally, paste a <strong>Collection ID</strong> from Unsplash to curate the photo style.
+          To find a collection ID: go to <a href="https://unsplash.com/collections" target="_blank" rel="noreferrer">unsplash.com/collections</a>,
+          open any collection, and copy the number from the URL —
+          e.g. <code>unsplash.com/collections/<strong>4324303</strong>/...</code>
+        </p>
+      </div>
+      <div class="l he">
+        <p>
+          אפשרי: הדבק <strong>Collection ID</strong> מ-Unsplash כדי לאצור את סגנון התמונה.
+          לאיתור מזהה אוסף: עבור אל <a href="https://unsplash.com/collections" target="_blank" rel="noreferrer">unsplash.com/collections</a>,
+          פתח כל אוסף, והעתק את המספר מה-URL —
+          למשל <code>unsplash.com/collections/<strong>4324303</strong>/...</code>
+        </p>
+      </div>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>A new photo loads each time you open a new tab.</p>
+      <p><span class="l en">A new photo loads each time you open a new tab.</span><span class="l he">תמונה חדשה נטענת בכל פעם שאתה פותח לשונית חדשה.</span></p>
     </div>
   </div>
 
-  <h3>Option B — Your own image</h3>
+  <h3><span class="l en">Option B — Your own image</span><span class="l he">אפשרות ב — תמונה משלך</span></h3>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Open Settings → <strong>Background</strong> tab. Select <strong>Local</strong>.</p>
+      <p><span class="l en">Open Settings → <strong>Background</strong> tab. Select <strong>Local</strong>.</span><span class="l he">פתח הגדרות → לשונית <strong>רקע</strong>. בחר <strong>מקומי</strong>.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>Click <strong>Choose image</strong> and select any photo from your device. It's stored locally — never uploaded anywhere.</p>
+      <p><span class="l en">Click <strong>Choose image</strong> and select any photo from your device. It's stored locally — never uploaded anywhere.</span><span class="l he">לחץ על <strong>בחר תמונה</strong> ובחר כל תמונה מהמכשיר שלך. היא מאוחסנת מקומית — לא מועלית לשום מקום.</span></p>
     </div>
   </div>
 
@@ -853,19 +958,19 @@
 
   <h2 id="weather">
     <span class="section-icon" style="background:rgba(56,189,248,0.12);">🌤</span>
-    Weather Widget
-    <span class="badge optional">Needs API Key</span>
+    <span class="l en">Weather Widget</span><span class="l he">ווידג'ט מזג אוויר</span>
+    <span class="badge optional"><span class="l en">Needs API Key</span><span class="l he">דורש מפתח API</span></span>
   </h2>
 
   <p>
-    The weather widget shows live temperature and conditions in the top bar.
-    It uses OpenWeatherMap's free tier — you need your own API key.
+    <span class="l en">The weather widget shows live temperature and conditions in the top bar. It uses OpenWeatherMap's free tier — you need your own API key.</span>
+    <span class="l he">ווידג'ט מזג האוויר מציג טמפרטורה ותנאים בזמן אמת בסרגל העליון. הוא משתמש ב-OpenWeatherMap חינמי — אתה צריך מפתח API משלך.</span>
   </p>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Go to <a href="https://openweathermap.org" target="_blank" rel="noreferrer">openweathermap.org</a> and create a free account.</p>
+      <p><span class="l en">Go to <a href="https://openweathermap.org" target="_blank" rel="noreferrer">openweathermap.org</a> and create a free account.</span><span class="l he">עבור אל <a href="https://openweathermap.org" target="_blank" rel="noreferrer">openweathermap.org</a> וצור חשבון חינמי.</span></p>
     </div>
   </div>
 
@@ -873,8 +978,8 @@
     <div class="step-num">2</div>
     <div class="step-body">
       <p>
-        In your account dashboard, go to <strong>API Keys</strong> and copy your default key
-        (or create a new one labelled something like <em>WindoM</em>).
+        <span class="l en">In your account dashboard, go to <strong>API Keys</strong> and copy your default key (or create a new one labelled something like <em>WindoM</em>).</span>
+        <span class="l he">בלוח הבקרה של חשבונך, עבור אל <strong>API Keys</strong> והעתק את המפתח ברירת המחדל (או צור חדש בשם כמו <em>WindoM</em>).</span>
       </p>
     </div>
   </div>
@@ -882,25 +987,27 @@
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>Open WindoM Settings → <strong>Weather</strong> tab. Paste your API key and enter your city name (e.g. <code>Tel Aviv</code> or <code>New York</code>). Choose °C or °F and click <strong>Save</strong>.</p>
+      <p><span class="l en">Open WindoM Settings → <strong>Weather</strong> tab. Paste your API key and enter your city name (e.g. <code>Tel Aviv</code> or <code>New York</code>). Choose °C or °F and click <strong>Save</strong>.</span><span class="l he">פתח הגדרות WindoM → לשונית <strong>מזג אוויר</strong>. הדבק את מפתח ה-API שלך והכנס את שם העיר שלך (למשל <code>Tel Aviv</code> או <code>New York</code>). בחר °C או °F ולחץ על <strong>שמור</strong>.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">4</div>
     <div class="step-body">
-      <p>The weather widget appears in the top-left of your new tab.</p>
+      <p><span class="l en">The weather widget appears in the top-left of your new tab.</span><span class="l he">ווידג'ט מזג האוויר מופיע בפינה השמאלית העליונה של לשונית החדשה שלך.</span></p>
     </div>
   </div>
 
   <div class="callout">
-    <strong>New API key not working?</strong>
-    OpenWeatherMap free keys can take up to 2 hours to activate after creation. If you get an error right after creating the key, wait a bit and try again.
+    <strong><span class="l en">New API key not working?</span><span class="l he">מפתח API חדש לא עובד?</span></strong>
+    <span class="l en">OpenWeatherMap free keys can take up to 2 hours to activate after creation. If you get an error right after creating the key, wait a bit and try again.</span>
+    <span class="l he">מפתחות OpenWeatherMap חינמיים יכולים לקחת עד 2 שעות להפעלה לאחר יצירה. אם קיבלת שגיאה מיד אחרי יצירת המפתח, המתן קצת ונסה שוב.</span>
   </div>
 
   <div class="callout tip">
-    <strong>Free tier limits</strong> — OpenWeatherMap's free plan allows 1,000 API calls per day.
-    WindoM caches the weather for 10 minutes per new tab, so you'll never come close to that limit.
+    <strong><span class="l en">Free tier limits</span><span class="l he">מגבלות גרסה חינמית</span></strong> —
+    <span class="l en">OpenWeatherMap's free plan allows 1,000 API calls per day. WindoM caches the weather for 10 minutes per new tab, so you'll never come close to that limit.</span>
+    <span class="l he">התוכנית החינמית של OpenWeatherMap מאפשרת 1,000 קריאות API ביום. WindoM שומר את מזג האוויר במטמון ל-10 דקות לכל לשונית חדשה, כך שלעולם לא תתקרב למגבלה.</span>
   </div>
 
 
@@ -910,32 +1017,32 @@
 
   <h2 id="links">
     <span class="section-icon" style="background:rgba(52,211,153,0.12);">🔗</span>
-    Quick Links &amp; Dock Bar
+    <span class="l en">Quick Links &amp; Dock Bar</span><span class="l he">קישורים מהירים וסרגל הדוק</span>
   </h2>
 
   <p>
-    Pin your most-used sites to the dock bar that runs across the top of every new tab.
-    Each link shows as a favicon icon — hover to see the label.
+    <span class="l en">Pin your most-used sites to the dock bar that runs across the top of every new tab. Each link shows as a favicon icon — hover to see the label.</span>
+    <span class="l he">נעץ את האתרים הנפוצים ביותר לסרגל הדוק שרץ לאורך חלק העליון של כל לשונית חדשה. כל קישור מוצג כסמל favicon — רחף מעליו לראות את התווית.</span>
   </p>
 
   <div class="step">
     <div class="step-num">1</div>
     <div class="step-body">
-      <p>Open Settings → <strong>Links</strong> tab.</p>
+      <p><span class="l en">Open Settings → <strong>Links</strong> tab.</span><span class="l he">פתח הגדרות → לשונית <strong>קישורים</strong>.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p>Click <strong>Add link</strong>. Enter the full URL (e.g. <code>https://github.com</code>) and a display name.</p>
+      <p><span class="l en">Click <strong>Add link</strong>. Enter the full URL (e.g. <code>https://github.com</code>) and a display name.</span><span class="l he">לחץ על <strong>הוסף קישור</strong>. הכנס את ה-URL המלא (למשל <code>https://github.com</code>) ושם תצוגה.</span></p>
     </div>
   </div>
 
   <div class="step">
     <div class="step-num">3</div>
     <div class="step-body">
-      <p>Drag to reorder. Click the <strong>×</strong> on any link to remove it.</p>
+      <p><span class="l en">Drag to reorder. Click the <strong>×</strong> on any link to remove it.</span><span class="l he">גרור לסידור מחדש. לחץ על <strong>×</strong> בכל קישור כדי להסירו.</span></p>
     </div>
   </div>
 
@@ -946,37 +1053,58 @@
 
   <h2 id="clock">
     <span class="section-icon" style="background:rgba(244,114,182,0.12);">🕐</span>
-    Clock &amp; Date
+    <span class="l en">Clock &amp; Date</span><span class="l he">שעון ותאריך</span>
   </h2>
 
   <p>
-    The clock is the centerpiece of your new tab. Everything about it is customizable.
+    <span class="l en">The clock is the centerpiece of your new tab. Everything about it is customizable.</span>
+    <span class="l he">השעון הוא מרכז לשונית החדשה שלך. הכל בו ניתן להתאמה אישית.</span>
   </p>
 
   <ul>
-    <li><strong>Format</strong> — 12-hour (with AM/PM) or 24-hour</li>
-    <li><strong>Size</strong> — small, medium, or large font</li>
-    <li><strong>Color</strong> — pick any color with the color picker</li>
-    <li><strong>Date</strong> — show or hide the date below the time; choose your preferred date format</li>
-    <li><strong>Style</strong> — plain digits or a more styled variant</li>
+    <li><strong><span class="l en">Format</span><span class="l he">פורמט</span></strong> — <span class="l en">12-hour (with AM/PM) or 24-hour</span><span class="l he">12 שעות (עם AM/PM) או 24 שעות</span></li>
+    <li><strong><span class="l en">Size</span><span class="l he">גודל</span></strong> — <span class="l en">small, medium, or large font</span><span class="l he">גופן קטן, בינוני או גדול</span></li>
+    <li><strong><span class="l en">Color</span><span class="l he">צבע</span></strong> — <span class="l en">pick any color with the color picker</span><span class="l he">בחר כל צבע עם בוחר הצבעים</span></li>
+    <li><strong><span class="l en">Date</span><span class="l he">תאריך</span></strong> — <span class="l en">show or hide the date below the time; choose your preferred date format</span><span class="l he">הצג או הסתר את התאריך מתחת לשעה; בחר פורמט תאריך מועדף</span></li>
+    <li><strong><span class="l en">Style</span><span class="l he">סגנון</span></strong> — <span class="l en">plain digits or a more styled variant</span><span class="l he">ספרות רגילות או גרסה בסגנון</span></li>
   </ul>
 
-  <p>All options are in Settings → <strong>Clock</strong> tab.</p>
+  <p><span class="l en">All options are in Settings → <strong>Clock</strong> tab.</span><span class="l he">כל האפשרויות נמצאות בהגדרות → לשונית <strong>שעון</strong>.</span></p>
 
 
 </div>
 
 <footer>
   <div style="margin-bottom:16px;">
-    <a href="/">Home</a>
+    <a href="/"><span class="l en">Home</span><span class="l he">דף הבית</span></a>
     <a href="https://chromewebstore.google.com/detail/windom/comcnbccalbfcegbmaemancbhgpijkpb">Chrome Web Store</a>
     <a href="https://github.com/YehudaBriskman/WindoM">GitHub</a>
-    <a href="local-setup.html">Local Setup</a>
-    <a href="privacy.html">Privacy Policy</a>
-    <a href="mailto:yehudabriskman@windom.app">Contact</a>
+    <a href="local-setup.html"><span class="l en">Local Setup</span><span class="l he">הגדרה מקומית</span></a>
+    <a href="privacy.html"><span class="l en">Privacy Policy</span><span class="l he">מדיניות פרטיות</span></a>
+    <a href="mailto:yehudabriskman@windom.app"><span class="l en">Contact</span><span class="l he">צור קשר</span></a>
   </div>
   <p>MIT License &copy; 2026 Yehuda Briskman &nbsp;&middot;&nbsp; <a href="mailto:yehudabriskman@windom.app" style="color:inherit;text-decoration:none;">yehudabriskman@windom.app</a></p>
 </footer>
+
+<script>
+  (function() {
+    var btn = document.getElementById('lang-btn');
+    if (!btn) return;
+
+    function updateBtn() {
+      btn.textContent = document.documentElement.lang === 'he' ? 'English' : 'עברית';
+    }
+
+    updateBtn();
+
+    btn.addEventListener('click', function() {
+      var next = document.documentElement.lang === 'he' ? 'en' : 'he';
+      document.documentElement.lang = next;
+      localStorage.setItem('guide-lang', next);
+      updateBtn();
+    });
+  })();
+</script>
 
 </body>
 </html>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1,0 +1,982 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WindoM - User Guide</title>
+  <meta name="description" content="How to use WindoM — connect Spotify, set up Google Calendar, use the Focus timer, and customize your new tab." />
+  <meta property="og:title" content="WindoM - User Guide" />
+  <meta property="og:description" content="Step-by-step guide to every WindoM feature — Spotify BYOA setup, Google Calendar, Focus timer, backgrounds, and more." />
+  <meta property="og:image" content="https://windom.app/images/preview.png" />
+  <meta property="og:url" content="https://windom.app/guide.html" />
+  <meta property="og:type" content="website" />
+  <link rel="canonical" href="https://windom.app/guide.html" />
+  <link rel="icon" type="image/png" sizes="16x16" href="icons/icon16.png" />
+  <link rel="icon" type="image/png" sizes="48x48" href="icons/icon48.png" />
+  <link rel="apple-touch-icon" href="icons/icon128.png" />
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #080810;
+      --surface: rgba(255,255,255,0.04);
+      --border: rgba(255,255,255,0.08);
+      --text: #e8e8f0;
+      --muted: #6b6b85;
+      --accent: #7b9ef5;
+      --accent2: #a78bfa;
+      --green: #6dca6d;
+      --amber: #e2b96e;
+      --spotify: #1DB954;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      font-family: 'Inter', sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.7;
+      overflow-x: hidden;
+    }
+
+    .wrap {
+      max-width: 780px;
+      margin: 0 auto;
+      padding: 0 24px 100px;
+      position: relative;
+      z-index: 1;
+    }
+
+    /* ── HEADER ── */
+    header {
+      padding: 64px 0 44px;
+      border-bottom: 1px solid var(--border);
+      margin-bottom: 52px;
+    }
+
+    .header-back {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted);
+      font-size: 0.85rem;
+      text-decoration: none;
+      margin-bottom: 28px;
+      transition: color 0.2s ease;
+    }
+    .header-back:hover { color: var(--accent); }
+    .header-back svg { width: 14px; height: 14px; }
+
+    .header-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: rgba(123,158,245,0.1);
+      border: 1px solid rgba(123,158,245,0.2);
+      border-radius: 999px;
+      padding: 5px 14px;
+      font-size: 0.76rem;
+      color: var(--accent);
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-weight: 600;
+      margin-bottom: 20px;
+    }
+
+    header h1 {
+      font-size: clamp(1.9rem, 4vw, 2.6rem);
+      font-weight: 700;
+      letter-spacing: -0.025em;
+      background: linear-gradient(135deg, #fff 30%, #a78bfa 70%, #7b9ef5 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+      margin-bottom: 12px;
+    }
+
+    header > p {
+      color: var(--muted);
+      font-size: 1.05rem;
+      margin-bottom: 0;
+    }
+
+    nav {
+      display: flex;
+      gap: 8px;
+      margin-top: 28px;
+      flex-wrap: wrap;
+    }
+
+    nav a {
+      color: var(--muted);
+      font-size: 0.85rem;
+      text-decoration: none;
+      padding: 5px 14px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+    }
+    nav a:hover {
+      color: var(--accent);
+      border-color: rgba(123,158,245,0.25);
+      background: rgba(123,158,245,0.06);
+    }
+
+    /* ── TYPOGRAPHY ── */
+    h2 {
+      font-size: 1.35rem;
+      font-weight: 700;
+      color: var(--text);
+      margin: 52px 0 16px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid var(--border);
+      letter-spacing: -0.02em;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    h2 .section-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      flex-shrink: 0;
+    }
+
+    h3 {
+      font-size: 0.78rem;
+      font-weight: 600;
+      color: var(--accent);
+      margin: 28px 0 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    p { color: var(--muted); margin-bottom: 12px; font-size: 0.97rem; }
+    ul, ol { color: var(--muted); padding-left: 22px; margin-bottom: 12px; font-size: 0.97rem; }
+    li { margin-bottom: 6px; }
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    strong { color: var(--text); }
+
+    /* ── CODE ── */
+    code {
+      background: rgba(255,255,255,0.06);
+      color: #e2c97e;
+      padding: 2px 7px;
+      border-radius: 5px;
+      font-size: 0.87em;
+      font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+      border: 1px solid rgba(255,255,255,0.08);
+      word-break: break-all;
+    }
+
+    pre {
+      background: rgba(0,0,0,0.35);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 18px 20px;
+      overflow-x: auto;
+      max-width: 100%;
+      margin: 12px 0 20px;
+    }
+
+    pre code {
+      background: none;
+      border: none;
+      padding: 0;
+      color: #d4d4d4;
+      font-size: 0.88rem;
+      white-space: pre;
+      word-break: normal;
+    }
+
+    /* ── BADGES ── */
+    .badge {
+      display: inline-block;
+      background: rgba(92,184,92,0.1);
+      color: var(--green);
+      border: 1px solid rgba(92,184,92,0.25);
+      border-radius: 999px;
+      padding: 3px 12px;
+      font-size: 0.72rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      margin-left: 8px;
+      vertical-align: middle;
+      text-transform: uppercase;
+    }
+    .badge.optional {
+      background: rgba(123,158,245,0.1);
+      color: var(--accent);
+      border-color: rgba(123,158,245,0.25);
+    }
+    .badge.byoa {
+      background: rgba(29,185,84,0.1);
+      color: var(--spotify);
+      border-color: rgba(29,185,84,0.25);
+    }
+
+    /* ── CALLOUTS ── */
+    .callout {
+      background: rgba(123,158,245,0.05);
+      border: 1px solid rgba(123,158,245,0.15);
+      border-left: 3px solid var(--accent);
+      border-radius: 0 10px 10px 0;
+      padding: 14px 18px;
+      margin: 16px 0;
+      color: var(--muted);
+      font-size: 0.93rem;
+    }
+    .callout strong { color: var(--text); }
+
+    .callout.tip {
+      background: rgba(92,184,92,0.05);
+      border-color: rgba(92,184,92,0.15);
+      border-left-color: var(--green);
+    }
+    .callout.warning {
+      background: rgba(226,185,110,0.05);
+      border-color: rgba(226,185,110,0.15);
+      border-left-color: var(--amber);
+    }
+    .callout.spotify {
+      background: rgba(29,185,84,0.05);
+      border-color: rgba(29,185,84,0.15);
+      border-left-color: var(--spotify);
+    }
+
+    /* ── STEPS ── */
+    .step {
+      display: flex;
+      gap: 16px;
+      margin-bottom: 20px;
+      align-items: flex-start;
+    }
+
+    .step-num {
+      min-width: 28px;
+      height: 28px;
+      background: rgba(123,158,245,0.12);
+      border: 1px solid rgba(123,158,245,0.25);
+      color: var(--accent);
+      border-radius: 50%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.82rem;
+      font-weight: 700;
+      margin-top: 2px;
+      flex-shrink: 0;
+    }
+
+    .step-body { flex: 1; min-width: 0; }
+    .step-body p { margin-bottom: 8px; }
+    .step-body p:last-child { margin-bottom: 0; }
+
+    /* ── SCREENSHOT PLACEHOLDER ── */
+    .screenshot {
+      width: 100%;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      margin: 16px 0;
+      display: block;
+      background: rgba(255,255,255,0.03);
+    }
+
+    /* ── WHAT YOU GET GRID ── */
+    .feature-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+      gap: 12px;
+      margin: 20px 0;
+    }
+
+    .feature-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 14px 16px;
+    }
+
+    .feature-card-title {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--text);
+      margin-bottom: 4px;
+    }
+
+    .feature-card-desc {
+      font-size: 0.8rem;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    /* ── REDIRECT URI BOX ── */
+    .redirect-uri-box {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      background: rgba(0,0,0,0.3);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 10px 14px;
+      margin: 10px 0;
+    }
+
+    .redirect-uri-label {
+      font-size: 0.75rem;
+      color: var(--muted);
+      white-space: nowrap;
+      font-weight: 500;
+    }
+
+    .redirect-uri-value {
+      font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+      font-size: 0.82rem;
+      color: #e2c97e;
+      word-break: break-all;
+      flex: 1;
+    }
+
+    /* ── FOOTER ── */
+    footer {
+      text-align: center;
+      padding: 40px 24px;
+      border-top: 1px solid var(--border);
+      color: var(--muted);
+      font-size: 0.85rem;
+      margin-top: 60px;
+    }
+
+    footer a { color: var(--muted); text-decoration: none; margin: 0 12px; }
+    footer a:hover { color: var(--text); }
+
+    /* ── ANIMATIONS ── */
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(20px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    header { animation: fadeUp 0.5s ease both; }
+
+    /* ── SCROLL-DRIVEN SVG BACKGROUND ── */
+    .scroll-bg {
+      position: fixed;
+      inset: 0;
+      z-index: 0;
+      pointer-events: none;
+      overflow: hidden;
+    }
+
+    .scroll-bg::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background-image: radial-gradient(circle, rgba(123,158,245,0.09) 1px, transparent 1px);
+      background-size: 48px 48px;
+      animation: dots-fade linear both;
+      animation-timeline: scroll(root);
+    }
+    @keyframes dots-fade {
+      from { opacity: 1; transform: translateY(0); }
+      to   { opacity: 0.25; transform: translateY(24px); }
+    }
+
+    .bg-svg { position: absolute; inset: 0; width: 100%; height: 100%; }
+
+    .bg-orb-1 {
+      animation: orb1-move linear both;
+      animation-timeline: scroll(root);
+    }
+    @keyframes orb1-move {
+      from { transform: translate(0, 0) scale(1); }
+      to   { transform: translate(70px, -160px) scale(1.18); }
+    }
+
+    .bg-orb-2 {
+      animation: orb2-move linear both;
+      animation-timeline: scroll(root);
+    }
+    @keyframes orb2-move {
+      from { transform: translate(0, 0) scale(1); opacity: 1; }
+      to   { transform: translate(-90px, -140px) scale(0.82); opacity: 0.45; }
+    }
+
+    .bg-path-1 {
+      stroke-dasharray: 3000;
+      stroke-dashoffset: 3000;
+      animation: path-draw-1 linear both;
+      animation-timeline: scroll(root);
+      animation-range: 0% 75%;
+    }
+    @keyframes path-draw-1 { to { stroke-dashoffset: 0; } }
+
+    .bg-path-2 {
+      stroke-dasharray: 3200;
+      stroke-dashoffset: 3200;
+      animation: path-draw-2 linear both;
+      animation-timeline: scroll(root);
+      animation-range: 10% 90%;
+    }
+    @keyframes path-draw-2 { to { stroke-dashoffset: 0; } }
+  </style>
+</head>
+<body>
+
+  <div class="scroll-bg" aria-hidden="true">
+    <svg class="bg-svg" viewBox="0 0 1440 900" preserveAspectRatio="xMidYMid slice" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <radialGradient id="g-blue" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stop-color="#7b9ef5" stop-opacity="0.38"/>
+          <stop offset="100%" stop-color="#7b9ef5" stop-opacity="0"/>
+        </radialGradient>
+        <radialGradient id="g-purple" cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stop-color="#a78bfa" stop-opacity="0.3"/>
+          <stop offset="100%" stop-color="#a78bfa" stop-opacity="0"/>
+        </radialGradient>
+      </defs>
+      <circle class="bg-orb bg-orb-1" cx="190" cy="270" r="300" fill="url(#g-blue)"/>
+      <circle class="bg-orb bg-orb-2" cx="1280" cy="520" r="240" fill="url(#g-purple)"/>
+      <path class="bg-path-1" d="M -220 380 Q 320 80 720 400 Q 1120 720 1660 280" stroke="#7b9ef5" stroke-width="1.2" stroke-opacity="0.18"/>
+      <path class="bg-path-2" d="M -220 640 Q 380 880 760 580 Q 1140 280 1660 620" stroke="#a78bfa" stroke-width="1" stroke-opacity="0.13"/>
+    </svg>
+  </div>
+
+<div class="wrap">
+
+  <header>
+    <a href="/" class="header-back">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M10 12L6 8l4-4"/>
+      </svg>
+      Back to home
+    </a>
+    <div class="header-badge">User Guide</div>
+    <h1>How to use WindoM</h1>
+    <p>Everything in one place — from connecting Spotify to customizing your clock.</p>
+    <nav>
+      <a href="#account">Account</a>
+      <a href="#spotify">Spotify</a>
+      <a href="#calendar">Calendar</a>
+      <a href="#focus">Focus Timer</a>
+      <a href="#background">Background</a>
+      <a href="#weather">Weather</a>
+      <a href="#links">Quick Links</a>
+      <a href="#clock">Clock</a>
+    </nav>
+  </header>
+
+
+  <!-- ─────────────────────────────────────────────────
+       WHAT WORKS WITHOUT AN ACCOUNT
+  ───────────────────────────────────────────────── -->
+
+  <div class="callout tip">
+    <strong>No account required for most things.</strong>
+    Clock, weather, todos, backgrounds, quotes, quick links, and the focus timer all work instantly with no sign-in.
+    An account is only needed for Google Calendar sync and Spotify. You can always add one later.
+  </div>
+
+  <div class="feature-grid">
+    <div class="feature-card">
+      <div class="feature-card-title">🕐 Clock &amp; Date</div>
+      <div class="feature-card-desc">12h / 24h, custom color, font size, date format. Always on, no account needed.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">🌤 Weather</div>
+      <div class="feature-card-desc">Live temperature and conditions. Needs a free OpenWeatherMap API key.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">🖼 Background</div>
+      <div class="feature-card-desc">Rotating Unsplash photos or upload your own image. Stored locally.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">⏱ Focus Timer</div>
+      <div class="feature-card-desc">Set an intention and dim everything else. No account needed.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">🔗 Quick Links</div>
+      <div class="feature-card-desc">Pin your most-used sites to the dock bar at the top.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">📋 Todos</div>
+      <div class="feature-card-desc">Local task list in the right sidebar. Stays on your device.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">🎵 Spotify</div>
+      <div class="feature-card-desc">Now-playing in the top dock. Needs an account + a free Spotify Developer app.</div>
+    </div>
+    <div class="feature-card">
+      <div class="feature-card-title">📅 Google Calendar</div>
+      <div class="feature-card-desc">Upcoming events in the right sidebar. Needs an account + Google authorization.</div>
+    </div>
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       ACCOUNT
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="account">
+    <span class="section-icon" style="background:rgba(123,158,245,0.1);">👤</span>
+    Create a WindoM Account
+    <span class="badge optional">Optional</span>
+  </h2>
+
+  <p>
+    A WindoM account syncs your settings across devices and is required to connect Google Calendar or Spotify.
+    Registration is free and takes under a minute.
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Open the gear icon (<strong>Settings</strong>) in the bottom-left corner of your new tab, then go to the <strong>Account</strong> tab.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>Enter your email address and a password (minimum 8 characters) and click <strong>Create account</strong>.</p>
+      <p>Or click <strong>Continue with Google</strong> if you prefer not to manage a password.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>Check your inbox for a verification email and click the link inside. You're signed in.</p>
+    </div>
+  </div>
+
+  <div class="callout tip">
+    <strong>Settings sync</strong> — once signed in, your clock format, background preference, widgets, and quick links all sync to the cloud and appear on any device where you're logged in to WindoM.
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       SPOTIFY
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="spotify">
+    <span class="section-icon" style="background:rgba(29,185,84,0.12);">🎵</span>
+    Connect Spotify
+    <span class="badge byoa">BYOA</span>
+  </h2>
+
+  <p>
+    WindoM shows your Spotify now-playing card directly in the new tab dock.
+    Because of how Spotify's API works, each user connects their own free Spotify Developer app —
+    this keeps your account private and avoids any shared rate limits.
+    The whole setup takes about 2 minutes.
+  </p>
+
+  <div class="callout spotify">
+    <strong>Why do I need my own app?</strong><br>
+    Spotify's Web API requires an OAuth app registered in their developer portal.
+    Instead of routing everyone through a shared WindoM app (which has quota limits and privacy implications),
+    each user creates their own free app — you get full control and there are no limits to worry about.
+  </div>
+
+  <h3>Before you start</h3>
+  <ul>
+    <li>You need a WindoM account (see above — free, takes 1 minute)</li>
+    <li>You need a Spotify account (free or premium both work)</li>
+  </ul>
+
+  <h3>Step 1 — Create a Spotify Developer app</h3>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Go to <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">developer.spotify.com/dashboard</a> and log in with your Spotify account.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>Click <strong>Create app</strong>.</p>
+      <ul>
+        <li><strong>App name</strong> — anything you like, e.g. <em>My WindoM</em></li>
+        <li><strong>App description</strong> — anything, e.g. <em>Personal WindoM integration</em></li>
+        <li><strong>Redirect URI</strong> — leave this empty for now, you'll add it in Step 2</li>
+        <li><strong>Which API/SDKs are you planning to use?</strong> — select <strong>Web API</strong></li>
+      </ul>
+      <p>Agree to the terms and click <strong>Save</strong>.</p>
+    </div>
+  </div>
+
+  <h3>Step 2 — Copy your Redirect URI from WindoM</h3>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>
+        Open your WindoM new tab, click <strong>Settings</strong> (gear icon, bottom-left), then go to the <strong>Spotify</strong> tab.
+      </p>
+      <p>
+        You'll see a box labelled <strong>Redirect URI</strong> with a value that looks like this:
+      </p>
+      <div class="redirect-uri-box">
+        <span class="redirect-uri-label">Redirect URI</span>
+        <span class="redirect-uri-value">https://&lt;your-extension-id&gt;.chromiumapp.org/</span>
+      </div>
+      <p>Click the <strong>Copy</strong> button next to it. This URI is unique to your Chrome installation — do not type it manually.</p>
+    </div>
+  </div>
+
+  <h3>Step 3 — Add the Redirect URI to your Spotify app</h3>
+
+  <div class="step">
+    <div class="step-num">4</div>
+    <div class="step-body">
+      <p>Go back to the <a href="https://developer.spotify.com/dashboard" target="_blank" rel="noreferrer">Spotify Developer Dashboard</a>, click on your app, then click <strong>Settings</strong> (top right of your app page).</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">5</div>
+    <div class="step-body">
+      <p>Scroll to the <strong>Redirect URIs</strong> field. Paste the URI you copied from WindoM, then click <strong>Add</strong>, then <strong>Save</strong> at the bottom.</p>
+    </div>
+  </div>
+
+  <div class="callout warning">
+    <strong>This step is easy to miss.</strong>
+    If you skip adding the Redirect URI you'll get an <em>Invalid Client</em> error when you try to connect.
+    The URI must match exactly — copy it using the button in WindoM, don't type it by hand.
+  </div>
+
+  <h3>Step 4 — Copy your Client ID and connect</h3>
+
+  <div class="step">
+    <div class="step-num">6</div>
+    <div class="step-body">
+      <p>Still on your Spotify app's Settings page, copy the <strong>Client ID</strong> at the top. It looks like a 32-character hex string, e.g. <code>b3d9a1f0c84e...</code></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">7</div>
+    <div class="step-body">
+      <p>Go back to WindoM → Settings → <strong>Spotify</strong> tab. Paste the Client ID into the input field and click <strong>Save &amp; Connect</strong>.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">8</div>
+    <div class="step-body">
+      <p>A Spotify authorization popup will appear. Click <strong>Agree</strong>.</p>
+      <p>You're connected. The now-playing card will appear in the top dock the next time you play a track.</p>
+    </div>
+  </div>
+
+  <h3>Troubleshooting</h3>
+
+  <div class="callout">
+    <strong>Error: Invalid Client</strong> — the Client ID is wrong or the Redirect URI wasn't saved correctly in the Spotify dashboard.
+    Double-check both. The Redirect URI must be copied from WindoM's Spotify tab, not typed manually.
+  </div>
+
+  <div class="callout">
+    <strong>Error: Connection cancelled</strong> — you closed the Spotify popup before completing authorization.
+    Click Save &amp; Connect again and complete the authorization flow.
+  </div>
+
+  <div class="callout tip">
+    <strong>Changed Chrome profile or reinstalled Chrome?</strong>
+    Your Redirect URI will be different. Go to Settings → Spotify tab to see the new URI,
+    add it to your Spotify app settings (you can have multiple Redirect URIs), then reconnect.
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       GOOGLE CALENDAR
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="calendar">
+    <span class="section-icon" style="background:rgba(66,133,244,0.12);">📅</span>
+    Connect Google Calendar
+  </h2>
+
+  <p>
+    WindoM pulls your upcoming Google Calendar events into the right sidebar so your day is always visible.
+    This requires a WindoM account and a one-time Google authorization.
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Make sure you have a WindoM account and are signed in (Settings → Account tab).</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>In the Account tab, scroll to <strong>Connected Services</strong>. Click <strong>Connect</strong> on the Google Calendar card.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>A Google authorization window opens. Choose your Google account and click <strong>Allow</strong>.</p>
+      <p>WindoM only requests read-only access to your calendar events — it cannot create, edit, or delete anything.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">4</div>
+    <div class="step-body">
+      <p>Done. Your upcoming events appear in the right sidebar, grouped by day.</p>
+    </div>
+  </div>
+
+  <div class="callout tip">
+    <strong>Look-ahead window</strong> — by default events for the next 7 days are shown.
+    You can change this to 14 or 30 days in Settings → <strong>Calendar</strong>.
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       FOCUS TIMER
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="focus">
+    <span class="section-icon" style="background:rgba(167,139,250,0.12);">⏱</span>
+    Focus Timer
+  </h2>
+
+  <p>
+    The focus timer lets you set an intention for your session.
+    While active, the background dims and all other UI fades away so nothing distracts you.
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Click the focus input in the center of your new tab — it says something like <em>"What are you working on?"</em></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>Type what you're working on and press <strong>Enter</strong>. The timer starts and the tab dims.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>When you're done, click anywhere on the screen or press <strong>Escape</strong> to exit focus mode.</p>
+    </div>
+  </div>
+
+  <div class="callout tip">
+    <strong>Focus presets</strong> — go to Settings → <strong>Focus</strong> to save your most common focus tasks as one-click presets, so you don't have to type the same thing every day.
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       BACKGROUND
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="background">
+    <span class="section-icon" style="background:rgba(245,158,11,0.12);">🖼</span>
+    Change Your Background
+  </h2>
+
+  <p>
+    WindoM supports two background sources: curated photos from Unsplash, or an image you upload from your device.
+  </p>
+
+  <h3>Option A — Unsplash photos</h3>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Open Settings → <strong>Background</strong> tab. Select <strong>Unsplash</strong>.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>
+        Optionally, paste a <strong>Collection ID</strong> from Unsplash to curate the photo style.
+        To find a collection ID: go to <a href="https://unsplash.com/collections" target="_blank" rel="noreferrer">unsplash.com/collections</a>,
+        open any collection, and copy the number from the URL —
+        e.g. <code>unsplash.com/collections/<strong>4324303</strong>/...</code>
+      </p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>A new photo loads each time you open a new tab.</p>
+    </div>
+  </div>
+
+  <h3>Option B — Your own image</h3>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Open Settings → <strong>Background</strong> tab. Select <strong>Local</strong>.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>Click <strong>Choose image</strong> and select any photo from your device. It's stored locally — never uploaded anywhere.</p>
+    </div>
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       WEATHER
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="weather">
+    <span class="section-icon" style="background:rgba(56,189,248,0.12);">🌤</span>
+    Weather Widget
+    <span class="badge optional">Needs API Key</span>
+  </h2>
+
+  <p>
+    The weather widget shows live temperature and conditions in the top bar.
+    It uses OpenWeatherMap's free tier — you need your own API key.
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Go to <a href="https://openweathermap.org" target="_blank" rel="noreferrer">openweathermap.org</a> and create a free account.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>
+        In your account dashboard, go to <strong>API Keys</strong> and copy your default key
+        (or create a new one labelled something like <em>WindoM</em>).
+      </p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>Open WindoM Settings → <strong>Weather</strong> tab. Paste your API key and enter your city name (e.g. <code>Tel Aviv</code> or <code>New York</code>). Choose °C or °F and click <strong>Save</strong>.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">4</div>
+    <div class="step-body">
+      <p>The weather widget appears in the top-left of your new tab.</p>
+    </div>
+  </div>
+
+  <div class="callout">
+    <strong>New API key not working?</strong>
+    OpenWeatherMap free keys can take up to 2 hours to activate after creation. If you get an error right after creating the key, wait a bit and try again.
+  </div>
+
+  <div class="callout tip">
+    <strong>Free tier limits</strong> — OpenWeatherMap's free plan allows 1,000 API calls per day.
+    WindoM caches the weather for 10 minutes per new tab, so you'll never come close to that limit.
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       QUICK LINKS
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="links">
+    <span class="section-icon" style="background:rgba(52,211,153,0.12);">🔗</span>
+    Quick Links &amp; Dock Bar
+  </h2>
+
+  <p>
+    Pin your most-used sites to the dock bar that runs across the top of every new tab.
+    Each link shows as a favicon icon — hover to see the label.
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p>Open Settings → <strong>Links</strong> tab.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p>Click <strong>Add link</strong>. Enter the full URL (e.g. <code>https://github.com</code>) and a display name.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p>Drag to reorder. Click the <strong>×</strong> on any link to remove it.</p>
+    </div>
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       CLOCK
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="clock">
+    <span class="section-icon" style="background:rgba(244,114,182,0.12);">🕐</span>
+    Clock &amp; Date
+  </h2>
+
+  <p>
+    The clock is the centerpiece of your new tab. Everything about it is customizable.
+  </p>
+
+  <ul>
+    <li><strong>Format</strong> — 12-hour (with AM/PM) or 24-hour</li>
+    <li><strong>Size</strong> — small, medium, or large font</li>
+    <li><strong>Color</strong> — pick any color with the color picker</li>
+    <li><strong>Date</strong> — show or hide the date below the time; choose your preferred date format</li>
+    <li><strong>Style</strong> — plain digits or a more styled variant</li>
+  </ul>
+
+  <p>All options are in Settings → <strong>Clock</strong> tab.</p>
+
+
+</div>
+
+<footer>
+  <div style="margin-bottom:16px;">
+    <a href="/">Home</a>
+    <a href="https://chromewebstore.google.com/detail/windom/comcnbccalbfcegbmaemancbhgpijkpb">Chrome Web Store</a>
+    <a href="https://github.com/YehudaBriskman/WindoM">GitHub</a>
+    <a href="local-setup.html">Local Setup</a>
+    <a href="privacy.html">Privacy Policy</a>
+    <a href="mailto:yehudabriskman@windom.app">Contact</a>
+  </div>
+  <p>MIT License &copy; 2026 Yehuda Briskman &nbsp;&middot;&nbsp; <a href="mailto:yehudabriskman@windom.app" style="color:inherit;text-decoration:none;">yehudabriskman@windom.app</a></p>
+</footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1174,6 +1174,9 @@
       <a href="https://chromewebstore.google.com/detail/windom/comcnbccalbfcegbmaemancbhgpijkpb" class="btn btn-primary">
         Try It Now
       </a>
+      <a href="guide.html" class="btn btn-secondary">
+        User Guide
+      </a>
       <a href="local-setup.html" class="btn btn-secondary">
         Run locally
       </a>
@@ -1643,6 +1646,7 @@
       <a href="https://chromewebstore.google.com/detail/windom/comcnbccalbfcegbmaemancbhgpijkpb">Chrome Web Store</a>
       <a href="https://github.com/YehudaBriskman/WindoM">GitHub</a>
       <a href="local-setup.html">Local Setup</a>
+      <a href="guide.html">User Guide</a>
       <a href="privacy.html">Privacy Policy</a>
       <a href="mailto:yehudabriskman@windom.app">Contact</a>
     </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { BackgroundProvider } from './contexts/BackgroundContext';
 import { FocusTimerProvider } from './contexts/FocusTimerContext';
 import { AuthProvider } from './contexts/AuthContext';
 import { useIntegrationSync } from './hooks/useIntegrationSync';
+import { useOnboarding } from './hooks/useOnboarding';
 import { BackgroundOverlay } from './components/background/BackgroundOverlay';
 import { PhotographerCredit } from './components/background/PhotographerCredit';
 import { TopBar } from './components/layout/TopBar';
@@ -14,6 +15,8 @@ import { RightSidebar } from './components/layout/RightSidebar';
 import { SpotifyPlayer } from './components/spotify/SpotifyPlayer';
 import { GlassFilters } from './components/GlassFilters';
 import { AppLoader } from './components/AppLoader';
+import { OnboardingModal } from './components/onboarding/OnboardingModal';
+import { SpotifyNotice } from './components/onboarding/SpotifyNotice';
 
 // Heavy non-critical chunks - loaded after the initial paint
 const SettingsPanel  = lazy(() => import('./components/settings/SettingsPanel').then(m => ({ default: m.SettingsPanel })));
@@ -23,8 +26,9 @@ const TabSidebar     = lazy(() => import('./components/tabs/TabSidebar').then(m 
 
 // Dashboard is always accessible - auth is optional.
 // Sign-in lives in Settings → Account tab.
-function Dashboard() {
+function Dashboard(): React.ReactElement {
   useIntegrationSync();
+  const { showOnboarding, showSpotifyNotice, completeOnboarding, dismissSpotifyNotice } = useOnboarding();
 
   return (
     <>
@@ -50,11 +54,14 @@ function Dashboard() {
         <TabSidebar />
       </Suspense>
       <PhotographerCredit />
+
+      {showOnboarding && <OnboardingModal onComplete={completeOnboarding} />}
+      {showSpotifyNotice && <SpotifyNotice onDismiss={dismissSpotifyNotice} />}
     </>
   );
 }
 
-export function App() {
+export function App(): React.ReactElement {
   return (
     <AuthProvider>
       <SettingsProvider>

--- a/web/src/components/layout/TopBar.tsx
+++ b/web/src/components/layout/TopBar.tsx
@@ -1,9 +1,11 @@
 import { WeatherWidget } from '../weather/WeatherWidget';
+import { GuidePanel } from '../onboarding/GuidePanel';
 
-export function TopBar() {
+export function TopBar(): React.ReactElement {
   return (
     <div className="top-bar">
       <WeatherWidget />
+      <GuidePanel />
     </div>
   );
 }

--- a/web/src/components/onboarding/GuidePanel.tsx
+++ b/web/src/components/onboarding/GuidePanel.tsx
@@ -1,11 +1,13 @@
 import { useState, useCallback } from 'react';
-import { HelpCircle, X, ChevronDown, ChevronRight } from 'lucide-react';
+import { HelpCircle, X, ChevronDown, ChevronRight, ExternalLink } from 'lucide-react';
 import { SETTINGS_EVENT } from '../../lib/settings-events';
+
+const GUIDE_URL = 'https://windom.app/guide.html';
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
 interface GuideBlock {
-  type: 'steps' | 'note' | 'tip' | 'code';
+  type: 'steps' | 'note' | 'tip';
   content: string | string[];
 }
 
@@ -16,181 +18,119 @@ interface GuideSection {
   blocks: GuideBlock[];
 }
 
-// ── Guide content ─────────────────────────────────────────────────────────────
+// ── Condensed fallback content (shown when offline or preferred) ──────────────
 
 const SECTIONS: GuideSection[] = [
   {
     id: 'spotify',
     title: 'Connect Spotify',
-    summary: 'See what\'s playing right in your new tab — requires a free Spotify Developer app.',
+    summary: 'Needs a free Spotify Developer app (BYOA) — takes ~2 min.',
     blocks: [
       {
         type: 'note',
-        content:
-          'WindoM uses your own Spotify Developer app (BYOA — Bring Your Own App). This is free and takes about 2 minutes. It keeps your account private and avoids any shared rate limits.',
+        content: 'WindoM uses your own Spotify app so your account stays private. It\'s free and takes about 2 minutes to set up.',
       },
       {
         type: 'steps',
         content: [
-          'Go to developer.spotify.com/dashboard and log in with your Spotify account.',
-          'Click "Create app". Give it any name and description (e.g. "My WindoM").',
-          'Set the Redirect URI field — you\'ll copy the correct value from WindoM in the next step.',
-          'Set "Which API/SDKs are you planning to use?" to "Web API". Agree to the terms and click Save.',
-          'Open WindoM Settings (gear icon, bottom-left) → Spotify tab.',
-          'You\'ll see your Redirect URI displayed there — copy it using the Copy button.',
-          'Go back to your Spotify app → Edit Settings → Redirect URIs → paste it → click Add → Save.',
-          'Back in the Spotify Dashboard, click on your app name and copy the Client ID.',
-          'Paste the Client ID into the WindoM Spotify tab and click "Save & Connect".',
-          'A Spotify authorization window will open — click Agree. You\'re connected.',
+          'Go to developer.spotify.com/dashboard and create a free app. Set API to "Web API".',
+          'Open WindoM Settings → Spotify tab. Copy the Redirect URI shown there using the Copy button.',
+          'Back in the Spotify Dashboard → your app → Settings → Redirect URIs → paste it → Add → Save.',
+          'Copy the Client ID from your Spotify app dashboard.',
+          'Paste it into WindoM Settings → Spotify tab and click "Save & Connect".',
+          'Authorize in the Spotify popup. Done — now-playing appears in your dock.',
         ],
       },
       {
         type: 'tip',
-        content:
-          'The Redirect URI is unique to your Chrome installation. If you reinstall Chrome or use a different profile, you\'ll need to add the new URI in your Spotify app settings.',
+        content: 'Getting "Invalid Client"? The Redirect URI wasn\'t saved in your Spotify app, or the Client ID is wrong. Use the Copy button — don\'t type the URI by hand.',
       },
     ],
   },
   {
     id: 'calendar',
     title: 'Connect Google Calendar',
-    summary: 'Pull your upcoming events into the right sidebar. Requires a WindoM account.',
+    summary: 'Shows upcoming events in the right sidebar. Needs a WindoM account.',
     blocks: [
       {
         type: 'steps',
         content: [
-          'Open Settings (gear icon, bottom-left) → Account tab.',
-          'Register or sign in to your WindoM account. You only need an email and password.',
-          'Once signed in, you\'ll see a "Connected Services" section with a Google Calendar card.',
-          'Click "Connect" on the Google Calendar card.',
-          'A Google authorization window opens — choose your Google account and click Allow.',
-          'Your upcoming events will now appear in the right sidebar automatically.',
+          'Sign in or create a WindoM account (Settings → Account tab).',
+          'In the Account tab, click "Connect" on the Google Calendar card.',
+          'Authorize in the Google popup — read-only access only.',
+          'Your events appear in the right sidebar, grouped by day.',
         ],
       },
       {
         type: 'tip',
-        content:
-          'Events are pulled for the next 7 days by default. You can change the look-ahead window (7, 14, or 30 days) in Settings → Calendar.',
+        content: 'Change the look-ahead window (7 / 14 / 30 days) in Settings → Calendar.',
       },
     ],
   },
   {
     id: 'focus',
-    title: 'Use the Focus Timer',
-    summary: 'Set an intention for your session — the tab dims everything else while you work.',
+    title: 'Focus Timer',
+    summary: 'Set an intention — the tab dims while you work.',
     blocks: [
       {
         type: 'steps',
         content: [
-          'Click the focus area in the center of your tab (or the text that says "What\'s your focus today?").',
+          'Click the focus input in the center of your tab.',
           'Type what you\'re working on and press Enter.',
-          'The timer starts and the background dims — only your focus text stays visible.',
-          'Click the timer or press Escape to exit focus mode.',
+          'Click anywhere or press Escape to exit focus mode.',
         ],
       },
       {
         type: 'tip',
-        content:
-          'You can set preset focus goals in Settings → Focus to quickly pick from your most common tasks.',
+        content: 'Save common tasks as presets in Settings → Focus.',
       },
     ],
   },
   {
     id: 'background',
     title: 'Change Your Background',
-    summary: 'Choose a curated Unsplash photo collection or upload your own image.',
+    summary: 'Rotating Unsplash photos or upload your own image.',
     blocks: [
       {
         type: 'steps',
         content: [
-          'Open Settings (gear icon, bottom-left) → Background tab.',
-          'Choose "Unsplash" for automatic rotating photos. You can paste a Collection ID to curate the style.',
-          'Or choose "Local" and upload any image from your device. It\'s stored privately on your device only.',
-          'The background updates on every new tab by default.',
+          'Open Settings → Background tab.',
+          'Choose Unsplash for curated rotating photos, or Local to upload your own.',
+          'For Unsplash: paste a Collection ID from the URL of any unsplash.com/collections page to curate the style.',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'weather',
+    title: 'Weather Widget',
+    summary: 'Live temperature in the top bar. Needs a free OpenWeatherMap key.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Create a free account at openweathermap.org and copy your API key.',
+          'Open Settings → Weather tab. Paste the key and set your city name.',
+          'Choose °C or °F and save.',
         ],
       },
       {
         type: 'note',
-        content:
-          'To use Unsplash with a custom collection, find a collection on unsplash.com, copy its ID from the URL, and paste it into the Collection ID field.',
+        content: 'New OpenWeatherMap keys can take up to 2 hours to activate.',
       },
     ],
   },
   {
     id: 'account',
     title: 'Create a WindoM Account',
-    summary: 'Optional — needed only for Google Calendar sync and Spotify. Everything else works without one.',
+    summary: 'Optional — only needed for Spotify and Google Calendar.',
     blocks: [
-      {
-        type: 'note',
-        content:
-          'Your account stores your settings in the cloud so they sync across devices. Clock, weather, background, todos, and quick links all work without an account.',
-      },
       {
         type: 'steps',
         content: [
           'Open Settings → Account tab.',
-          'Enter your email and a password (minimum 8 characters) and click "Create account".',
-          'Check your inbox for a verification email and click the link.',
-          'You\'re signed in — your settings now sync to the cloud.',
-        ],
-      },
-      {
-        type: 'tip',
-        content:
-          'You can also sign in with Google if you prefer not to manage a password.',
-      },
-    ],
-  },
-  {
-    id: 'weather',
-    title: 'Set Up the Weather Widget',
-    summary: 'Show live temperature and conditions in the top bar. Requires a free OpenWeatherMap key.',
-    blocks: [
-      {
-        type: 'steps',
-        content: [
-          'Go to openweathermap.org, create a free account, and copy your API key.',
-          'Open Settings → Weather tab.',
-          'Paste your API key and set your city name (e.g. "Tel Aviv" or "New York").',
-          'Choose °C or °F and click Save. The widget appears in the top bar.',
-        ],
-      },
-      {
-        type: 'note',
-        content:
-          'Free OpenWeatherMap accounts have a generous limit (1,000 calls/day) — more than enough for personal use.',
-      },
-    ],
-  },
-  {
-    id: 'links',
-    title: 'Quick Links & Dock Bar',
-    summary: 'Pin your most-used sites to the dock at the top of every tab.',
-    blocks: [
-      {
-        type: 'steps',
-        content: [
-          'Open Settings → Links tab.',
-          'Click "Add link", enter the URL and a display name.',
-          'Drag to reorder. Click the × to remove a link.',
-          'Links appear as icons in the dock bar across the top of your tab.',
-        ],
-      },
-    ],
-  },
-  {
-    id: 'clock',
-    title: 'Customize the Clock',
-    summary: 'Change the time format, size, color, and whether the date is shown.',
-    blocks: [
-      {
-        type: 'steps',
-        content: [
-          'Open Settings → Clock tab.',
-          'Toggle between 12-hour and 24-hour format.',
-          'Adjust the font size and pick a color using the color picker.',
-          'Enable or disable the date display and choose your preferred date format.',
+          'Enter your email and a password (min 8 characters), then click "Create account".',
+          'Verify your email via the link sent to your inbox.',
         ],
       },
     ],
@@ -203,13 +143,10 @@ function renderBlock(block: GuideBlock, idx: number): React.ReactElement {
   if (block.type === 'steps' && Array.isArray(block.content)) {
     return (
       <ol className="guide-block-steps" key={idx}>
-        {block.content.map((step, i) => (
-          <li key={i}>{step}</li>
-        ))}
+        {block.content.map((step, i) => <li key={i}>{step}</li>)}
       </ol>
     );
   }
-
   if (block.type === 'note') {
     return (
       <div className="guide-block-note" key={idx}>
@@ -218,35 +155,19 @@ function renderBlock(block: GuideBlock, idx: number): React.ReactElement {
       </div>
     );
   }
-
-  if (block.type === 'tip') {
-    return (
-      <div className="guide-block-tip" key={idx}>
-        <span className="guide-block-label">Tip</span>
-        <p>{block.content as string}</p>
-      </div>
-    );
-  }
-
   return (
-    <pre className="guide-block-code" key={idx}>
-      <code>{block.content as string}</code>
-    </pre>
+    <div className="guide-block-tip" key={idx}>
+      <span className="guide-block-label">Tip</span>
+      <p>{block.content as string}</p>
+    </div>
   );
 }
 
-// ── Collapsible section ───────────────────────────────────────────────────────
-
 function GuideSectionItem({ section, defaultOpen = false }: { section: GuideSection; defaultOpen?: boolean }): React.ReactElement {
   const [open, setOpen] = useState(defaultOpen);
-
   return (
     <div className={`guide-section${open ? ' open' : ''}`}>
-      <button
-        className="guide-section-header"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-      >
+      <button className="guide-section-header" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
         <div className="guide-section-meta">
           <span className="guide-section-title">{section.title}</span>
           <span className="guide-section-summary">{section.summary}</span>
@@ -255,7 +176,6 @@ function GuideSectionItem({ section, defaultOpen = false }: { section: GuideSect
           {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
         </span>
       </button>
-
       {open && (
         <div className="guide-section-body">
           {section.blocks.map((block, i) => renderBlock(block, i))}
@@ -273,6 +193,10 @@ export function GuidePanel(): React.ReactElement {
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
 
+  function openFullGuide(): void {
+    window.open(GUIDE_URL, '_blank', 'noopener,noreferrer');
+  }
+
   function openSettings(): void {
     document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.TOGGLE));
     close();
@@ -288,14 +212,13 @@ export function GuidePanel(): React.ReactElement {
         <>
           <div className="guide-backdrop" onClick={close} />
           <div className="guide-panel" role="dialog" aria-modal="true" aria-label="WindoM Guide">
+
             <div className="guide-panel-header">
               <div>
                 <div className="guide-panel-title">Help &amp; Guide</div>
                 <div className="guide-panel-subtitle">
                   Settings are in the{' '}
-                  <button className="guide-inline-link" onClick={openSettings}>
-                    gear icon
-                  </button>
+                  <button className="guide-inline-link" onClick={openSettings}>gear icon</button>
                   , bottom-left.
                 </div>
               </div>
@@ -304,15 +227,24 @@ export function GuidePanel(): React.ReactElement {
               </button>
             </div>
 
+            {/* Primary CTA — full guide on website */}
+            <button className="guide-full-link" onClick={openFullGuide}>
+              <div className="guide-full-link-text">
+                <span className="guide-full-link-title">Full guide with photos</span>
+                <span className="guide-full-link-sub">windom.app/guide — opens in a new tab</span>
+              </div>
+              <ExternalLink size={15} className="guide-full-link-icon" />
+            </button>
+
+            {/* Fallback — condensed in-app reference */}
+            <div className="guide-fallback-label">Quick reference</div>
+
             <div className="guide-panel-body">
               {SECTIONS.map((section, i) => (
-                <GuideSectionItem
-                  key={section.id}
-                  section={section}
-                  defaultOpen={i === 0}
-                />
+                <GuideSectionItem key={section.id} section={section} defaultOpen={i === 0} />
               ))}
             </div>
+
           </div>
         </>
       )}

--- a/web/src/components/onboarding/GuidePanel.tsx
+++ b/web/src/components/onboarding/GuidePanel.tsx
@@ -1,77 +1,282 @@
 import { useState, useCallback } from 'react';
-import { HelpCircle, X, Image, Music, Calendar, Timer, Link2, Settings } from 'lucide-react';
+import { HelpCircle, X, ChevronDown, ChevronRight } from 'lucide-react';
+import { SETTINGS_EVENT } from '../../lib/settings-events';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface GuideBlock {
+  type: 'steps' | 'note' | 'tip' | 'code';
+  content: string | string[];
+}
 
 interface GuideSection {
-  icon: React.ReactNode;
+  id: string;
   title: string;
-  steps: string[];
+  summary: string;
+  blocks: GuideBlock[];
 }
+
+// ── Guide content ─────────────────────────────────────────────────────────────
 
 const SECTIONS: GuideSection[] = [
   {
-    icon: <Image size={16} />,
-    title: 'Change your background',
-    steps: [
-      'Open Settings (gear icon, bottom-left)',
-      'Go to the Background tab',
-      'Choose Unsplash for curated photos, or upload your own image',
-    ],
-  },
-  {
-    icon: <Timer size={16} />,
-    title: 'Use the Focus timer',
-    steps: [
-      'Click the focus area in the center of your tab',
-      'Type what you\'re working on and press Enter',
-      'Your timer starts — the tab dims everything else',
-    ],
-  },
-  {
-    icon: <Music size={16} />,
+    id: 'spotify',
     title: 'Connect Spotify',
-    steps: [
-      'Open Settings → Account tab',
-      'Sign in or create a WindoM account',
-      'Click "Connect Spotify" and authorize the app',
-      'Now-playing appears in the top dock automatically',
+    summary: 'See what\'s playing right in your new tab — requires a free Spotify Developer app.',
+    blocks: [
+      {
+        type: 'note',
+        content:
+          'WindoM uses your own Spotify Developer app (BYOA — Bring Your Own App). This is free and takes about 2 minutes. It keeps your account private and avoids any shared rate limits.',
+      },
+      {
+        type: 'steps',
+        content: [
+          'Go to developer.spotify.com/dashboard and log in with your Spotify account.',
+          'Click "Create app". Give it any name and description (e.g. "My WindoM").',
+          'Set the Redirect URI field — you\'ll copy the correct value from WindoM in the next step.',
+          'Set "Which API/SDKs are you planning to use?" to "Web API". Agree to the terms and click Save.',
+          'Open WindoM Settings (gear icon, bottom-left) → Spotify tab.',
+          'You\'ll see your Redirect URI displayed there — copy it using the Copy button.',
+          'Go back to your Spotify app → Edit Settings → Redirect URIs → paste it → click Add → Save.',
+          'Back in the Spotify Dashboard, click on your app name and copy the Client ID.',
+          'Paste the Client ID into the WindoM Spotify tab and click "Save & Connect".',
+          'A Spotify authorization window will open — click Agree. You\'re connected.',
+        ],
+      },
+      {
+        type: 'tip',
+        content:
+          'The Redirect URI is unique to your Chrome installation. If you reinstall Chrome or use a different profile, you\'ll need to add the new URI in your Spotify app settings.',
+      },
     ],
   },
   {
-    icon: <Calendar size={16} />,
+    id: 'calendar',
     title: 'Connect Google Calendar',
-    steps: [
-      'Open Settings → Account tab',
-      'Sign in or create a WindoM account',
-      'Click "Connect Google Calendar" and authorize',
-      'Your events appear in the right sidebar',
+    summary: 'Pull your upcoming events into the right sidebar. Requires a WindoM account.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Open Settings (gear icon, bottom-left) → Account tab.',
+          'Register or sign in to your WindoM account. You only need an email and password.',
+          'Once signed in, you\'ll see a "Connected Services" section with a Google Calendar card.',
+          'Click "Connect" on the Google Calendar card.',
+          'A Google authorization window opens — choose your Google account and click Allow.',
+          'Your upcoming events will now appear in the right sidebar automatically.',
+        ],
+      },
+      {
+        type: 'tip',
+        content:
+          'Events are pulled for the next 7 days by default. You can change the look-ahead window (7, 14, or 30 days) in Settings → Calendar.',
+      },
     ],
   },
   {
-    icon: <Link2 size={16} />,
-    title: 'Add quick links',
-    steps: [
-      'Open Settings → Links tab',
-      'Add or reorder your favourite sites',
-      'They appear in the dock bar at the top',
+    id: 'focus',
+    title: 'Use the Focus Timer',
+    summary: 'Set an intention for your session — the tab dims everything else while you work.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Click the focus area in the center of your tab (or the text that says "What\'s your focus today?").',
+          'Type what you\'re working on and press Enter.',
+          'The timer starts and the background dims — only your focus text stays visible.',
+          'Click the timer or press Escape to exit focus mode.',
+        ],
+      },
+      {
+        type: 'tip',
+        content:
+          'You can set preset focus goals in Settings → Focus to quickly pick from your most common tasks.',
+      },
     ],
   },
   {
-    icon: <Settings size={16} />,
-    title: 'Customize everything',
-    steps: [
-      'Clock format, size, and color — Clock tab',
-      'Weather widget and location — Weather tab',
-      'Daily quotes on or off — Quotes tab',
-      'General tab for your name and search engine',
+    id: 'background',
+    title: 'Change Your Background',
+    summary: 'Choose a curated Unsplash photo collection or upload your own image.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Open Settings (gear icon, bottom-left) → Background tab.',
+          'Choose "Unsplash" for automatic rotating photos. You can paste a Collection ID to curate the style.',
+          'Or choose "Local" and upload any image from your device. It\'s stored privately on your device only.',
+          'The background updates on every new tab by default.',
+        ],
+      },
+      {
+        type: 'note',
+        content:
+          'To use Unsplash with a custom collection, find a collection on unsplash.com, copy its ID from the URL, and paste it into the Collection ID field.',
+      },
+    ],
+  },
+  {
+    id: 'account',
+    title: 'Create a WindoM Account',
+    summary: 'Optional — needed only for Google Calendar sync and Spotify. Everything else works without one.',
+    blocks: [
+      {
+        type: 'note',
+        content:
+          'Your account stores your settings in the cloud so they sync across devices. Clock, weather, background, todos, and quick links all work without an account.',
+      },
+      {
+        type: 'steps',
+        content: [
+          'Open Settings → Account tab.',
+          'Enter your email and a password (minimum 8 characters) and click "Create account".',
+          'Check your inbox for a verification email and click the link.',
+          'You\'re signed in — your settings now sync to the cloud.',
+        ],
+      },
+      {
+        type: 'tip',
+        content:
+          'You can also sign in with Google if you prefer not to manage a password.',
+      },
+    ],
+  },
+  {
+    id: 'weather',
+    title: 'Set Up the Weather Widget',
+    summary: 'Show live temperature and conditions in the top bar. Requires a free OpenWeatherMap key.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Go to openweathermap.org, create a free account, and copy your API key.',
+          'Open Settings → Weather tab.',
+          'Paste your API key and set your city name (e.g. "Tel Aviv" or "New York").',
+          'Choose °C or °F and click Save. The widget appears in the top bar.',
+        ],
+      },
+      {
+        type: 'note',
+        content:
+          'Free OpenWeatherMap accounts have a generous limit (1,000 calls/day) — more than enough for personal use.',
+      },
+    ],
+  },
+  {
+    id: 'links',
+    title: 'Quick Links & Dock Bar',
+    summary: 'Pin your most-used sites to the dock at the top of every tab.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Open Settings → Links tab.',
+          'Click "Add link", enter the URL and a display name.',
+          'Drag to reorder. Click the × to remove a link.',
+          'Links appear as icons in the dock bar across the top of your tab.',
+        ],
+      },
+    ],
+  },
+  {
+    id: 'clock',
+    title: 'Customize the Clock',
+    summary: 'Change the time format, size, color, and whether the date is shown.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Open Settings → Clock tab.',
+          'Toggle between 12-hour and 24-hour format.',
+          'Adjust the font size and pick a color using the color picker.',
+          'Enable or disable the date display and choose your preferred date format.',
+        ],
+      },
     ],
   },
 ];
+
+// ── Renderers ─────────────────────────────────────────────────────────────────
+
+function renderBlock(block: GuideBlock, idx: number): React.ReactElement {
+  if (block.type === 'steps' && Array.isArray(block.content)) {
+    return (
+      <ol className="guide-block-steps" key={idx}>
+        {block.content.map((step, i) => (
+          <li key={i}>{step}</li>
+        ))}
+      </ol>
+    );
+  }
+
+  if (block.type === 'note') {
+    return (
+      <div className="guide-block-note" key={idx}>
+        <span className="guide-block-label">Note</span>
+        <p>{block.content as string}</p>
+      </div>
+    );
+  }
+
+  if (block.type === 'tip') {
+    return (
+      <div className="guide-block-tip" key={idx}>
+        <span className="guide-block-label">Tip</span>
+        <p>{block.content as string}</p>
+      </div>
+    );
+  }
+
+  return (
+    <pre className="guide-block-code" key={idx}>
+      <code>{block.content as string}</code>
+    </pre>
+  );
+}
+
+// ── Collapsible section ───────────────────────────────────────────────────────
+
+function GuideSectionItem({ section, defaultOpen = false }: { section: GuideSection; defaultOpen?: boolean }): React.ReactElement {
+  const [open, setOpen] = useState(defaultOpen);
+
+  return (
+    <div className={`guide-section${open ? ' open' : ''}`}>
+      <button
+        className="guide-section-header"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <div className="guide-section-meta">
+          <span className="guide-section-title">{section.title}</span>
+          <span className="guide-section-summary">{section.summary}</span>
+        </div>
+        <span className="guide-section-chevron">
+          {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+      </button>
+
+      {open && (
+        <div className="guide-section-body">
+          {section.blocks.map((block, i) => renderBlock(block, i))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Root component ────────────────────────────────────────────────────────────
 
 export function GuidePanel(): React.ReactElement {
   const [isOpen, setIsOpen] = useState(false);
 
   const open = useCallback(() => setIsOpen(true), []);
   const close = useCallback(() => setIsOpen(false), []);
+
+  function openSettings(): void {
+    document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.TOGGLE));
+    close();
+  }
 
   return (
     <>
@@ -84,25 +289,28 @@ export function GuidePanel(): React.ReactElement {
           <div className="guide-backdrop" onClick={close} />
           <div className="guide-panel" role="dialog" aria-modal="true" aria-label="WindoM Guide">
             <div className="guide-panel-header">
-              <span className="guide-panel-title">Help &amp; Guide</span>
+              <div>
+                <div className="guide-panel-title">Help &amp; Guide</div>
+                <div className="guide-panel-subtitle">
+                  Settings are in the{' '}
+                  <button className="guide-inline-link" onClick={openSettings}>
+                    gear icon
+                  </button>
+                  , bottom-left.
+                </div>
+              </div>
               <button className="guide-panel-close" onClick={close} aria-label="Close guide">
                 <X size={16} />
               </button>
             </div>
 
             <div className="guide-panel-body">
-              {SECTIONS.map((section) => (
-                <div className="guide-section" key={section.title}>
-                  <div className="guide-section-title">
-                    {section.icon}
-                    <span>{section.title}</span>
-                  </div>
-                  <ol className="guide-section-steps">
-                    {section.steps.map((step) => (
-                      <li key={step}>{step}</li>
-                    ))}
-                  </ol>
-                </div>
+              {SECTIONS.map((section, i) => (
+                <GuideSectionItem
+                  key={section.id}
+                  section={section}
+                  defaultOpen={i === 0}
+                />
               ))}
             </div>
           </div>

--- a/web/src/components/onboarding/GuidePanel.tsx
+++ b/web/src/components/onboarding/GuidePanel.tsx
@@ -1,0 +1,113 @@
+import { useState, useCallback } from 'react';
+import { HelpCircle, X, Image, Music, Calendar, Timer, Link2, Settings } from 'lucide-react';
+
+interface GuideSection {
+  icon: React.ReactNode;
+  title: string;
+  steps: string[];
+}
+
+const SECTIONS: GuideSection[] = [
+  {
+    icon: <Image size={16} />,
+    title: 'Change your background',
+    steps: [
+      'Open Settings (gear icon, bottom-left)',
+      'Go to the Background tab',
+      'Choose Unsplash for curated photos, or upload your own image',
+    ],
+  },
+  {
+    icon: <Timer size={16} />,
+    title: 'Use the Focus timer',
+    steps: [
+      'Click the focus area in the center of your tab',
+      'Type what you\'re working on and press Enter',
+      'Your timer starts — the tab dims everything else',
+    ],
+  },
+  {
+    icon: <Music size={16} />,
+    title: 'Connect Spotify',
+    steps: [
+      'Open Settings → Account tab',
+      'Sign in or create a WindoM account',
+      'Click "Connect Spotify" and authorize the app',
+      'Now-playing appears in the top dock automatically',
+    ],
+  },
+  {
+    icon: <Calendar size={16} />,
+    title: 'Connect Google Calendar',
+    steps: [
+      'Open Settings → Account tab',
+      'Sign in or create a WindoM account',
+      'Click "Connect Google Calendar" and authorize',
+      'Your events appear in the right sidebar',
+    ],
+  },
+  {
+    icon: <Link2 size={16} />,
+    title: 'Add quick links',
+    steps: [
+      'Open Settings → Links tab',
+      'Add or reorder your favourite sites',
+      'They appear in the dock bar at the top',
+    ],
+  },
+  {
+    icon: <Settings size={16} />,
+    title: 'Customize everything',
+    steps: [
+      'Clock format, size, and color — Clock tab',
+      'Weather widget and location — Weather tab',
+      'Daily quotes on or off — Quotes tab',
+      'General tab for your name and search engine',
+    ],
+  },
+];
+
+export function GuidePanel(): React.ReactElement {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      <button className="guide-btn" onClick={open} aria-label="Help & Guide">
+        <HelpCircle size={18} />
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="guide-backdrop" onClick={close} />
+          <div className="guide-panel" role="dialog" aria-modal="true" aria-label="WindoM Guide">
+            <div className="guide-panel-header">
+              <span className="guide-panel-title">Help &amp; Guide</span>
+              <button className="guide-panel-close" onClick={close} aria-label="Close guide">
+                <X size={16} />
+              </button>
+            </div>
+
+            <div className="guide-panel-body">
+              {SECTIONS.map((section) => (
+                <div className="guide-section" key={section.title}>
+                  <div className="guide-section-title">
+                    {section.icon}
+                    <span>{section.title}</span>
+                  </div>
+                  <ol className="guide-section-steps">
+                    {section.steps.map((step) => (
+                      <li key={step}>{step}</li>
+                    ))}
+                  </ol>
+                </div>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/web/src/components/onboarding/OnboardingModal.tsx
+++ b/web/src/components/onboarding/OnboardingModal.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { Image, Timer, Music, Calendar, Sparkles, ArrowRight, X } from 'lucide-react';
+
+interface Props {
+  onComplete: () => Promise<void>;
+}
+
+interface Step {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}
+
+const STEPS: Step[] = [
+  {
+    icon: <Sparkles size={36} />,
+    title: 'Welcome to WindoM',
+    description: 'Your personal new tab — a calm, focused space for everything you need throughout the day.',
+  },
+  {
+    icon: <Image size={36} />,
+    title: 'Set your background',
+    description: 'Pick a stunning Unsplash photo or upload your own image. Open Settings → Background to get started.',
+  },
+  {
+    icon: <Timer size={36} />,
+    title: 'Stay focused',
+    description: 'Use the Focus timer to set an intention and block distractions. Click the focus area in the center of your tab.',
+  },
+  {
+    icon: <Music size={36} />,
+    title: 'Connect Spotify',
+    description: 'See what\'s playing right in your new tab. Go to Settings → Account to link your Spotify account.',
+  },
+  {
+    icon: <Calendar size={36} />,
+    title: 'Connect your calendar',
+    description: 'Pull in Google Calendar events so your day is always visible. Settings → Account → Connect Google Calendar.',
+  },
+];
+
+export function OnboardingModal({ onComplete }: Props): React.ReactElement {
+  const [step, setStep] = useState(0);
+  const isLast = step === STEPS.length - 1;
+  const current = STEPS[step];
+
+  function next(): void {
+    if (isLast) {
+      void onComplete();
+    } else {
+      setStep((s) => s + 1);
+    }
+  }
+
+  function prev(): void {
+    setStep((s) => Math.max(0, s - 1));
+  }
+
+  return (
+    <div className="onboarding-backdrop">
+      <div className="onboarding-modal" role="dialog" aria-modal="true" aria-label="Welcome to WindoM">
+        <button className="onboarding-skip" onClick={() => void onComplete()} aria-label="Skip onboarding">
+          <X size={16} />
+        </button>
+
+        <div className="onboarding-icon">{current.icon}</div>
+
+        <div className="onboarding-body">
+          <h2 className="onboarding-title">{current.title}</h2>
+          <p className="onboarding-description">{current.description}</p>
+        </div>
+
+        <div className="onboarding-dots">
+          {STEPS.map((_, i) => (
+            <button
+              key={i}
+              className={`onboarding-dot${i === step ? ' active' : ''}`}
+              onClick={() => setStep(i)}
+              aria-label={`Go to step ${i + 1}`}
+            />
+          ))}
+        </div>
+
+        <div className="onboarding-footer">
+          {step > 0 && (
+            <button className="onboarding-btn-back" onClick={prev}>
+              Back
+            </button>
+          )}
+          <button className="onboarding-btn-next" onClick={next}>
+            {isLast ? 'Get started' : (
+              <>Next <ArrowRight size={14} /></>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/OnboardingModal.tsx
+++ b/web/src/components/onboarding/OnboardingModal.tsx
@@ -30,12 +30,12 @@ const STEPS: Step[] = [
   {
     icon: <Music size={36} />,
     title: 'Connect Spotify',
-    description: 'See what\'s playing right in your new tab. Go to Settings → Account to link your Spotify account.',
+    description: 'WindoM uses your own free Spotify Developer app — no shared limits. Create one at developer.spotify.com, add your redirect URI from Settings → Spotify, paste your Client ID, and hit connect. Full steps are in the ? guide.',
   },
   {
     icon: <Calendar size={36} />,
-    title: 'Connect your calendar',
-    description: 'Pull in Google Calendar events so your day is always visible. Settings → Account → Connect Google Calendar.',
+    title: 'Connect Google Calendar',
+    description: 'Create a free WindoM account (Settings → Account), then click "Connect Google Calendar". Your upcoming events will appear in the right sidebar.',
   },
 ];
 

--- a/web/src/components/onboarding/SpotifyNotice.tsx
+++ b/web/src/components/onboarding/SpotifyNotice.tsx
@@ -1,0 +1,31 @@
+import { Music, X } from 'lucide-react';
+import { SETTINGS_EVENT } from '../../lib/settings-events';
+
+interface Props {
+  onDismiss: () => Promise<void>;
+}
+
+export function SpotifyNotice({ onDismiss }: Props): React.ReactElement {
+  function openAccount(): void {
+    document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.OPEN_ACCOUNT));
+    void onDismiss();
+  }
+
+  return (
+    <div className="spotify-notice" role="status">
+      <div className="spotify-notice-icon">
+        <Music size={18} />
+      </div>
+      <div className="spotify-notice-content">
+        <span className="spotify-notice-title">Spotify is now available</span>
+        <span className="spotify-notice-sub">See what&apos;s playing right in your new tab.</span>
+      </div>
+      <button className="spotify-notice-connect" onClick={openAccount}>
+        Connect
+      </button>
+      <button className="spotify-notice-dismiss" onClick={() => void onDismiss()} aria-label="Dismiss">
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/onboarding/SpotifyNotice.tsx
+++ b/web/src/components/onboarding/SpotifyNotice.tsx
@@ -18,7 +18,7 @@ export function SpotifyNotice({ onDismiss }: Props): React.ReactElement {
       </div>
       <div className="spotify-notice-content">
         <span className="spotify-notice-title">Spotify is now available</span>
-        <span className="spotify-notice-sub">See what&apos;s playing right in your new tab.</span>
+        <span className="spotify-notice-sub">Takes 2 min — needs a free Spotify Developer app. See the ? guide for steps.</span>
       </div>
       <button className="spotify-notice-connect" onClick={openAccount}>
         Connect

--- a/web/src/hooks/useOnboarding.ts
+++ b/web/src/hooks/useOnboarding.ts
@@ -1,0 +1,66 @@
+import { useState, useEffect, useCallback } from 'react';
+import { localStore } from '../lib/chrome-storage';
+
+const ONBOARDING_KEY = 'windom_onboarding';
+
+interface OnboardingState {
+  completed: boolean;
+  spotifyNoticeDismissed: boolean;
+}
+
+interface UseOnboardingReturn {
+  showOnboarding: boolean;
+  showSpotifyNotice: boolean;
+  completeOnboarding: () => Promise<void>;
+  dismissSpotifyNotice: () => Promise<void>;
+}
+
+export function useOnboarding(): UseOnboardingReturn {
+  const [state, setState] = useState<OnboardingState | null>(null);
+
+  useEffect(() => {
+    async function init(): Promise<void> {
+      const stored = await localStore.get<OnboardingState | null>(ONBOARDING_KEY, null);
+
+      if (stored !== null) {
+        setState(stored);
+        return;
+      }
+
+      // First time this key exists — detect new vs existing user by whether
+      // they already have synced settings from a previous session.
+      const syncData = await chrome.storage.sync.get(null);
+      const isExistingUser = Object.keys(syncData).length > 0;
+
+      const initial: OnboardingState = {
+        completed: isExistingUser,
+        // New users get onboarding instead of the notice; existing users get notice.
+        spotifyNoticeDismissed: !isExistingUser,
+      };
+
+      await localStore.set(ONBOARDING_KEY, initial);
+      setState(initial);
+    }
+
+    void init();
+  }, []);
+
+  const completeOnboarding = useCallback(async (): Promise<void> => {
+    const next: OnboardingState = { completed: true, spotifyNoticeDismissed: true };
+    await localStore.set(ONBOARDING_KEY, next);
+    setState(next);
+  }, []);
+
+  const dismissSpotifyNotice = useCallback(async (): Promise<void> => {
+    const next: OnboardingState = { ...(state ?? { completed: true, spotifyNoticeDismissed: false }), spotifyNoticeDismissed: true };
+    await localStore.set(ONBOARDING_KEY, next);
+    setState(next);
+  }, [state]);
+
+  return {
+    showOnboarding: state !== null && !state.completed,
+    showSpotifyNotice: state !== null && state.completed && !state.spotifyNoticeDismissed,
+    completeOnboarding,
+    dismissSpotifyNotice,
+  };
+}

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3533,3 +3533,374 @@ body.focus-exiting .sidebar-container {
   color: rgba(250, 190, 70, 0.9);
 }
 
+/* ============================================================
+   Onboarding Modal
+   ============================================================ */
+.onboarding-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2000;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: onboarding-fade-in 0.3s ease;
+}
+
+@keyframes onboarding-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.onboarding-modal {
+  position: relative;
+  width: min(420px, 90vw);
+  padding: 36px 32px 28px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  animation: onboarding-slide-up 0.35s var(--spring-gentle);
+}
+
+@keyframes onboarding-slide-up {
+  from { opacity: 0; transform: translateY(20px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0)    scale(1);    }
+}
+
+.onboarding-skip {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  padding: 4px 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, color 0.2s;
+}
+.onboarding-skip:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.onboarding-icon {
+  color: rgba(255, 255, 255, 0.75);
+  margin-bottom: 4px;
+}
+
+.onboarding-body {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.onboarding-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+  letter-spacing: -0.01em;
+}
+
+.onboarding-description {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.6);
+  line-height: 1.55;
+}
+
+.onboarding-dots {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.onboarding-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.25);
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s, transform 0.2s;
+}
+.onboarding-dot.active {
+  background: rgba(255, 255, 255, 0.85);
+  transform: scale(1.2);
+}
+
+.onboarding-footer {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  margin-top: 4px;
+}
+
+.onboarding-btn-back {
+  flex: 0 0 auto;
+  padding: 9px 18px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.65);
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+.onboarding-btn-back:hover {
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.onboarding-btn-next {
+  flex: 1;
+  padding: 9px 18px;
+  border-radius: 10px;
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: background 0.2s;
+}
+.onboarding-btn-next:hover {
+  background: rgba(255, 255, 255, 0.26);
+}
+
+/* ============================================================
+   Spotify Notice (existing-user one-time banner)
+   ============================================================ */
+.spotify-notice {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1500;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  backdrop-filter: blur(28px) saturate(160%);
+  -webkit-backdrop-filter: blur(28px) saturate(160%);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  animation: notice-slide-up 0.4s var(--spring-gentle);
+  white-space: nowrap;
+}
+
+@keyframes notice-slide-up {
+  from { opacity: 0; transform: translateX(-50%) translateY(16px); }
+  to   { opacity: 1; transform: translateX(-50%) translateY(0);     }
+}
+
+.spotify-notice-icon {
+  color: rgba(255, 255, 255, 0.7);
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.spotify-notice-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.spotify-notice-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.spotify-notice-sub {
+  font-size: 0.775rem;
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.spotify-notice-connect {
+  padding: 6px 14px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.9);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+  flex-shrink: 0;
+}
+.spotify-notice-connect:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.spotify-notice-dismiss {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.4);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  transition: color 0.2s;
+  flex-shrink: 0;
+}
+.spotify-notice-dismiss:hover {
+  color: rgba(255, 255, 255, 0.75);
+}
+
+/* ============================================================
+   Guide Button & Panel
+   ============================================================ */
+.guide-btn {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 50%;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, transform 0.2s;
+  flex-shrink: 0;
+}
+.guide-btn:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.95);
+  transform: scale(1.08);
+}
+
+.guide-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  background: rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  animation: onboarding-fade-in 0.2s ease;
+}
+
+.guide-panel {
+  position: fixed;
+  top: 60px;
+  right: 16px;
+  z-index: 1201;
+  width: min(360px, calc(100vw - 32px));
+  max-height: calc(100vh - 80px);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  backdrop-filter: blur(40px) saturate(180%);
+  -webkit-backdrop-filter: blur(40px) saturate(180%);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  animation: onboarding-slide-up 0.3s var(--spring-gentle);
+}
+
+.guide-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 18px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+}
+
+.guide-panel-title {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.guide-panel-close {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+  color: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  padding: 3px 5px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, color 0.2s;
+}
+.guide-panel-close:hover {
+  background: rgba(255, 255, 255, 0.14);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.guide-panel-body {
+  overflow-y: auto;
+  padding: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.guide-section {
+  padding: 10px 18px;
+  border-radius: 0;
+}
+.guide-section:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.guide-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.8);
+  margin-bottom: 8px;
+}
+
+.guide-section-steps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  counter-reset: guide-step;
+}
+
+.guide-section-steps li {
+  counter-increment: guide-step;
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.5);
+  line-height: 1.45;
+  padding-left: 18px;
+  position: relative;
+}
+.guide-section-steps li::before {
+  content: counter(guide-step) '.';
+  position: absolute;
+  left: 0;
+  color: rgba(255, 255, 255, 0.3);
+  font-size: 0.75rem;
+}
+

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3806,14 +3806,14 @@ body.focus-exiting .sidebar-container {
   top: 60px;
   right: 16px;
   z-index: 1201;
-  width: min(360px, calc(100vw - 32px));
+  width: min(400px, calc(100vw - 32px));
   max-height: calc(100vh - 80px);
   border-radius: 16px;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.07);
+  border: 1px solid rgba(255, 255, 255, 0.13);
   backdrop-filter: blur(40px) saturate(180%);
   -webkit-backdrop-filter: blur(40px) saturate(180%);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -3822,16 +3822,38 @@ body.focus-exiting .sidebar-container {
 
 .guide-panel-header {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  padding: 16px 18px 14px;
+  padding: 16px 18px 13px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
   flex-shrink: 0;
+  gap: 10px;
 }
 
 .guide-panel-title {
   font-size: 0.95rem;
   font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+  line-height: 1.3;
+}
+
+.guide-panel-subtitle {
+  font-size: 0.775rem;
+  color: rgba(255, 255, 255, 0.4);
+  margin-top: 2px;
+}
+
+.guide-inline-link {
+  background: none;
+  border: none;
+  color: rgba(255, 255, 255, 0.65);
+  cursor: pointer;
+  text-decoration: underline;
+  font-size: inherit;
+  padding: 0;
+  transition: color 0.15s;
+}
+.guide-inline-link:hover {
   color: rgba(255, 255, 255, 0.9);
 }
 
@@ -3846,61 +3868,191 @@ body.focus-exiting .sidebar-container {
   align-items: center;
   justify-content: center;
   transition: background 0.2s, color 0.2s;
+  flex-shrink: 0;
 }
 .guide-panel-close:hover {
   background: rgba(255, 255, 255, 0.14);
   color: rgba(255, 255, 255, 0.85);
 }
 
+/* ── Scrollable body ── */
 .guide-panel-body {
   overflow-y: auto;
-  padding: 12px 0;
+  padding: 6px 0 12px;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+}
+.guide-panel-body::-webkit-scrollbar {
+  width: 4px;
+}
+.guide-panel-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+.guide-panel-body::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15);
+  border-radius: 2px;
 }
 
+/* ── Collapsible section ── */
 .guide-section {
-  padding: 10px 18px;
-  border-radius: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
-.guide-section:hover {
+.guide-section:last-child {
+  border-bottom: none;
+}
+
+.guide-section-header {
+  width: 100%;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 12px 18px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  text-align: left;
+  transition: background 0.15s;
+}
+.guide-section-header:hover {
   background: rgba(255, 255, 255, 0.04);
+}
+.guide-section.open .guide-section-header {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.guide-section-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  flex: 1;
+  min-width: 0;
 }
 
 .guide-section-title {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 0.85rem;
+  font-size: 0.875rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.8);
-  margin-bottom: 8px;
+  color: rgba(255, 255, 255, 0.88);
+  line-height: 1.3;
 }
 
-.guide-section-steps {
+.guide-section-summary {
+  font-size: 0.775rem;
+  color: rgba(255, 255, 255, 0.42);
+  line-height: 1.4;
+}
+
+.guide-section-chevron {
+  color: rgba(255, 255, 255, 0.35);
+  flex-shrink: 0;
+  margin-top: 2px;
+  transition: color 0.15s;
+}
+.guide-section-header:hover .guide-section-chevron {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+/* ── Section body ── */
+.guide-section-body {
+  padding: 0 18px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* ── Numbered steps ── */
+.guide-block-steps {
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 7px;
   counter-reset: guide-step;
 }
-
-.guide-section-steps li {
+.guide-block-steps li {
   counter-increment: guide-step;
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.5);
-  line-height: 1.45;
-  padding-left: 18px;
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 1.5;
+  padding-left: 22px;
   position: relative;
 }
-.guide-section-steps li::before {
-  content: counter(guide-step) '.';
+.guide-block-steps li::before {
+  content: counter(guide-step);
   position: absolute;
   left: 0;
+  top: 0;
+  width: 16px;
+  height: 16px;
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 50%;
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 16px;
+  text-align: center;
+}
+
+/* ── Note callout ── */
+.guide-block-note {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.guide-block-note p {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.58);
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* ── Tip callout ── */
+.guide-block-tip {
+  background: rgba(255, 220, 100, 0.07);
+  border: 1px solid rgba(255, 220, 100, 0.18);
+  border-radius: 8px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.guide-block-tip p {
+  font-size: 0.8rem;
+  color: rgba(255, 220, 100, 0.7);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.guide-block-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: rgba(255, 255, 255, 0.3);
+}
+.guide-block-tip .guide-block-label {
+  color: rgba(255, 220, 100, 0.5);
+}
+
+/* ── Code block ── */
+.guide-block-code {
+  background: rgba(0, 0, 0, 0.25);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  padding: 8px 10px;
+  overflow-x: auto;
   font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
+  font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
+  line-height: 1.5;
+  margin: 0;
 }
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3806,26 +3806,26 @@ body.focus-exiting .sidebar-container {
   top: 60px;
   right: 16px;
   z-index: 1201;
-  width: min(400px, calc(100vw - 32px));
-  max-height: calc(100vh - 80px);
-  border-radius: 16px;
+  width: min(360px, calc(100vw - 32px));
+  max-height: min(480px, calc(100vh - 80px));
+  border-radius: 14px;
   background: rgba(255, 255, 255, 0.07);
-  border: 1px solid rgba(255, 255, 255, 0.13);
+  border: 1px solid rgba(255, 255, 255, 0.12);
   backdrop-filter: blur(40px) saturate(180%);
   -webkit-backdrop-filter: blur(40px) saturate(180%);
-  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.45);
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  animation: onboarding-slide-up 0.3s var(--spring-gentle);
+  animation: onboarding-slide-up 0.25s var(--spring-gentle);
 }
 
 .guide-panel-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  padding: 16px 18px 13px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 13px 15px 11px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.07);
   flex-shrink: 0;
   gap: 10px;
 }
@@ -3881,8 +3881,8 @@ body.focus-exiting .sidebar-container {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin: 0 12px 0;
-  padding: 11px 14px;
+  margin: 10px 12px 0;
+  padding: 9px 12px;
   border-radius: 10px;
   background: rgba(123, 158, 245, 0.1);
   border: 1px solid rgba(123, 158, 245, 0.22);
@@ -3920,7 +3920,7 @@ body.focus-exiting .sidebar-container {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: rgba(255, 255, 255, 0.22);
-  padding: 10px 18px 4px;
+  padding: 8px 14px 3px;
 }
 
 /* ── Scrollable body ── */
@@ -3954,19 +3954,19 @@ body.focus-exiting .sidebar-container {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 12px 18px;
+  padding: 9px 14px;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
   text-align: left;
   transition: background 0.15s;
 }
 .guide-section-header:hover {
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.03);
 }
 .guide-section.open .guide-section-header {
-  background: rgba(255, 255, 255, 0.05);
+  background: none;
 }
 
 .guide-section-meta {
@@ -4002,10 +4002,10 @@ body.focus-exiting .sidebar-container {
 
 /* ── Section body ── */
 .guide-section-body {
-  padding: 0 18px 14px;
+  padding: 0 14px 10px;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 8px;
 }
 
 /* ── Numbered steps ── */
@@ -4015,7 +4015,7 @@ body.focus-exiting .sidebar-container {
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 7px;
+  gap: 5px;
   counter-reset: guide-step;
 }
 .guide-block-steps li {
@@ -4049,16 +4049,16 @@ body.focus-exiting .sidebar-container {
 .guide-block-note {
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 7px;
+  padding: 8px 10px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
 }
 .guide-block-note p {
-  font-size: 0.8rem;
-  color: rgba(255, 255, 255, 0.58);
-  line-height: 1.5;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.55);
+  line-height: 1.45;
   margin: 0;
 }
 
@@ -4066,16 +4066,16 @@ body.focus-exiting .sidebar-container {
 .guide-block-tip {
   background: rgba(255, 220, 100, 0.07);
   border: 1px solid rgba(255, 220, 100, 0.18);
-  border-radius: 8px;
-  padding: 10px 12px;
+  border-radius: 7px;
+  padding: 8px 10px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 3px;
 }
 .guide-block-tip p {
-  font-size: 0.8rem;
-  color: rgba(255, 220, 100, 0.7);
-  line-height: 1.5;
+  font-size: 0.78rem;
+  color: rgba(255, 220, 100, 0.68);
+  line-height: 1.45;
   margin: 0;
 }
 

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3875,6 +3875,54 @@ body.focus-exiting .sidebar-container {
   color: rgba(255, 255, 255, 0.85);
 }
 
+/* ── Full guide CTA ── */
+.guide-full-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0 12px 0;
+  padding: 11px 14px;
+  border-radius: 10px;
+  background: rgba(123, 158, 245, 0.1);
+  border: 1px solid rgba(123, 158, 245, 0.22);
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.2s, border-color 0.2s;
+}
+.guide-full-link:hover {
+  background: rgba(123, 158, 245, 0.17);
+  border-color: rgba(123, 158, 245, 0.38);
+}
+.guide-full-link-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.guide-full-link-title {
+  font-size: 0.855rem;
+  font-weight: 600;
+  color: rgba(123, 158, 245, 0.95);
+}
+.guide-full-link-sub {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.38);
+}
+.guide-full-link-icon {
+  color: rgba(123, 158, 245, 0.7);
+  flex-shrink: 0;
+}
+
+/* ── Fallback divider ── */
+.guide-fallback-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.22);
+  padding: 10px 18px 4px;
+}
+
 /* ── Scrollable body ── */
 .guide-panel-body {
   overflow-y: auto;


### PR DESCRIPTION
## What
- New-user 5-step onboarding modal shown only on first install
- One-time Spotify connection banner for existing users (pre-Spotify era)
- Persistent `?` Help & Guide panel accessible from the top bar at all times

## Why
Users had no in-app guidance when features were added silently. New users landed with no context and missed key features. Existing users didn't know Spotify integration existed. Without a persistent reference, users who dismissed onboarding had no way to rediscover how things work.

## How
Detection logic in `useOnboarding.ts` reads `windom_onboarding` from `chrome.storage.local`. On first load ever, it checks `chrome.storage.sync` — if sync has data the user is existing (show Spotify notice), if empty they're new (show onboarding flow). Completion flags are written back to local storage so flows never repeat. `GuidePanel` is self-contained: renders both the `?` trigger button and the panel, placed in `TopBar`. CSS follows the glass convention — no Tailwind for backgrounds/borders/shadows.

## Test plan
- [ ] Fresh install (clear all storage): onboarding modal appears, step navigation works, skip closes it
- [ ] After completing onboarding: modal never appears again on reload
- [ ] Existing user (sync storage populated, no `windom_onboarding` key): Spotify notice appears at bottom
- [ ] Dismiss Spotify notice: never reappears on reload
- [ ] `?` button in top-right opens guide panel; backdrop click closes it
- [ ] New user does NOT see the Spotify notice (onboarding covers it)
- [ ] Existing user does NOT see the onboarding modal

Closes #167, #168, #169

Generated by [Claude-Bot] of [@Yehuda Briskman]