### PR TITLE
fix: phase 2 backend security hardening

### DIFF
--- a/backend/drizzle/0006_hash_session_ip_useragent.sql
+++ b/backend/drizzle/0006_hash_session_ip_useragent.sql
@@ -1,0 +1,3 @@
+-- Convert ip column from inet to text so it can store SHA-256 hex hashes.
+-- Existing plaintext IPs are cast to text (lossless); future inserts will be hashed.
+ALTER TABLE "refresh_sessions" ALTER COLUMN "ip" TYPE text USING "ip"::text;

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -36,6 +36,20 @@
       "when": 1776242620918,
       "tag": "0004_conscious_killraven",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776600000000,
+      "tag": "0005_overrated_raider",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1776600001000,
+      "tag": "0006_hash_session_ip_useragent",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -120,12 +120,16 @@ export async function buildApp({ skipRateLimit, ...overrides }: BuildAppOptions 
 
     const statusCode = error.statusCode ?? 500;
     app.log.error({ statusCode, message: error.message, stack: error.stack }, 'Request error');
-    // In production, never leak internal error messages or stack traces to clients.
     const isClientError = statusCode >= 400 && statusCode < 500;
+    // In production, never send internal error details to clients — log-only.
     void reply.status(statusCode).send({
       statusCode,
       error: isClientError ? error.name : 'Internal Server Error',
-      message: isClientError || !config.isProd ? error.message : 'An unexpected error occurred',
+      message: !config.isProd
+        ? error.message
+        : isClientError
+        ? 'Invalid request'
+        : 'An unexpected error occurred',
     });
   });
 

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -7,7 +7,11 @@ const envSchema = z.object({
   DATABASE_URL: z.string().url(),
   JWT_ACCESS_SECRET: z.string().min(32),
   REFRESH_TOKEN_SECRET: z.string().min(32),
-  TOKEN_ENC_KEY_BASE64: z.string().min(1),
+  TOKEN_ENC_KEY_BASE64: z.string().min(1).refine(
+    (val) => { try { return Buffer.from(val, 'base64').length === 32; } catch { return false; } },
+    { message: 'TOKEN_ENC_KEY_BASE64 must decode to exactly 32 bytes (AES-256 key)' },
+  ),
+  CHROME_EXTENSION_ID: z.string().optional(),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   GOOGLE_REDIRECT_URI: z.string().url().optional(),

--- a/backend/src/controllers/calendar.controller.ts
+++ b/backend/src/controllers/calendar.controller.ts
@@ -1,9 +1,18 @@
+import { z } from 'zod';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import * as calendarService from '../services/calendar.service.js';
 
+const calendarQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(90).default(7),
+});
+
 export async function getCalendarEventsController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const { days = '7' } = req.query as { days?: string };
-  const result = await calendarService.getCalendarEvents(req.user.sub, parseInt(days, 10) || 7);
+  const parsed = calendarQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    void reply.status(400).send({ statusCode: 400, error: 'Bad Request', message: 'days must be an integer between 1 and 90' });
+    return;
+  }
+  const result = await calendarService.getCalendarEvents(req.user.sub, parsed.data.days);
 
   if (!result.ok) {
     if (result.error === 'NOT_CONNECTED') {

--- a/backend/src/controllers/spotify.controller.ts
+++ b/backend/src/controllers/spotify.controller.ts
@@ -22,9 +22,18 @@ export async function getNowPlayingController(req: FastifyRequest, reply: Fastif
   void reply.send(result.data);
 }
 
+const topTracksQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+  time_range: z.enum(['short_term', 'medium_term', 'long_term']).default('short_term'),
+});
+
 export async function getTopTracksController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const { limit = '10', time_range = 'short_term' } = req.query as { limit?: string; time_range?: string };
-  const result = await spotifyService.getTopTracks(req.user.sub, parseInt(limit, 10) || 10, time_range);
+  const parsed = topTracksQuerySchema.safeParse(req.query);
+  if (!parsed.success) {
+    void reply.status(400).send({ statusCode: 400, error: 'Bad Request', message: 'limit must be 1–50; time_range must be short_term, medium_term, or long_term' });
+    return;
+  }
+  const result = await spotifyService.getTopTracks(req.user.sub, parsed.data.limit, parsed.data.time_range);
   if (!result.ok) { sendSpotifyError(result.error, reply); return; }
   reply.header('Cache-Control', 'private, max-age=300');
   void reply.send({ tracks: result.data });

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -4,7 +4,6 @@ import {
   text,
   timestamp,
   boolean,
-  inet,
   index,
   uniqueIndex,
   integer,
@@ -38,7 +37,8 @@ export const refreshSessions = pgTable(
     rotatedFromId: uuid('rotated_from_id'),
     revokedAt: timestamp('revoked_at', { withTimezone: true }),
     userAgent: text('user_agent').notNull().default(''),
-    ip: inet('ip').notNull(),
+    /** SHA-256 hex of the client IP — stored hashed for anomaly detection, never as plaintext. */
+    ip: text('ip').notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     renewalCount: integer('renewal_count').notNull().default(0),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),

--- a/backend/src/plugins/cors.ts
+++ b/backend/src/plugins/cors.ts
@@ -21,8 +21,11 @@ export async function registerCors(app: FastifyInstance): Promise<void> {
         return cb(null, true);
       }
 
-      // In dev, allow any chrome-extension:// origin (extension ID changes between dev builds)
-      if (!config.isProd && origin.startsWith('chrome-extension://')) {
+      // When CHROME_EXTENSION_ID is set, enforce the specific extension origin in all envs.
+      if (config.CHROME_EXTENSION_ID) {
+        if (origin === `chrome-extension://${config.CHROME_EXTENSION_ID}`) return cb(null, true);
+      } else if (!config.isProd && origin.startsWith('chrome-extension://')) {
+        // In dev without a pinned ID, allow any extension origin (ID changes between builds).
         return cb(null, true);
       }
 

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -5,7 +5,8 @@ export function authRoutes(app: FastifyInstance): void {
   app.post('/register', { config: { rateLimit: { max: 5, timeWindow: '15 minutes' } } }, registerController);
   // 5 attempts per 15 min (~480/day) - OWASP recommended threshold for brute-force prevention
   app.post('/login', { config: { rateLimit: { max: 5, timeWindow: '15 minutes' } } }, loginController);
-  app.post('/refresh', { config: { rateLimit: { max: 30, timeWindow: '15 minutes' } } }, refreshController);
+  // 5 refreshes per 15 min is sufficient for all legitimate tab/startup usage
+  app.post('/refresh', { config: { rateLimit: { max: 5, timeWindow: '15 minutes' } } }, refreshController);
   // Rate limit logout to prevent session enumeration via rapid token probing
   app.post('/logout', { config: { rateLimit: { max: 20, timeWindow: '1 hour' } } }, logoutController);
 }

--- a/backend/src/services/__tests__/calendar.service.test.ts
+++ b/backend/src/services/__tests__/calendar.service.test.ts
@@ -40,7 +40,7 @@ describe('getCalendarEvents', () => {
 
   it('returns TOKEN_REFRESH_FAILED when access token is unavailable', async () => {
     dbReturnsAccount(mockAccount());
-    mockGetToken.mockResolvedValue(null);
+    mockGetToken.mockResolvedValue({ ok: false, error: 'TOKEN_REFRESH_FAILED' });
 
     const result = await getCalendarEvents('user-1', 7);
 
@@ -50,7 +50,7 @@ describe('getCalendarEvents', () => {
 
   it('returns an empty array when all calendar fetches fail', async () => {
     dbReturnsAccount(mockAccount());
-    mockGetToken.mockResolvedValue('access-token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'access-token' });
 
     // calendarList fails → falls back to primary; then primary events fetch fails
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
@@ -63,7 +63,7 @@ describe('getCalendarEvents', () => {
 
   it('returns events from the primary calendar', async () => {
     dbReturnsAccount(mockAccount());
-    mockGetToken.mockResolvedValue('access-token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'access-token' });
 
     const calListResponse = {
       ok: true,
@@ -100,7 +100,7 @@ describe('getCalendarEvents', () => {
 
   it('deduplicates events appearing in multiple calendar responses', async () => {
     dbReturnsAccount(mockAccount());
-    mockGetToken.mockResolvedValue('access-token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'access-token' });
 
     const calListResponse = {
       ok: true,
@@ -140,7 +140,7 @@ describe('getCalendarEvents', () => {
 
   it('clamps days to MAX_CALENDAR_DAYS', async () => {
     dbReturnsAccount(mockAccount());
-    mockGetToken.mockResolvedValue('access-token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'access-token' });
 
     const mockFetch = vi.fn().mockResolvedValue({ ok: false });
     vi.stubGlobal('fetch', mockFetch);

--- a/backend/src/services/__tests__/spotify.service.test.ts
+++ b/backend/src/services/__tests__/spotify.service.test.ts
@@ -37,7 +37,7 @@ beforeEach(() => {
 describe('getNowPlaying', () => {
   it('returns NOT_CONNECTED when no spotify account exists', async () => {
     dbReturnsAccount(null);
-    mockGetToken.mockResolvedValue(null);
+    mockGetToken.mockResolvedValue({ ok: false, error: 'NOT_CONNECTED' });
 
     const result = await getNowPlaying('user-1');
 
@@ -47,7 +47,7 @@ describe('getNowPlaying', () => {
 
   it('returns isPlaying: false and null track on 204 response', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 204, ok: true }));
 
@@ -62,7 +62,7 @@ describe('getNowPlaying', () => {
 
   it('returns API_ERROR on non-ok response', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ status: 500, ok: false }));
 
@@ -74,7 +74,7 @@ describe('getNowPlaying', () => {
 
   it('returns normalized track data when playing', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       status: 200,
@@ -98,7 +98,7 @@ describe('getNowPlaying', () => {
 describe('getTopTracks', () => {
   it('returns NOT_CONNECTED when token is unavailable', async () => {
     dbReturnsAccount(null);
-    mockGetToken.mockResolvedValue(null);
+    mockGetToken.mockResolvedValue({ ok: false, error: 'NOT_CONNECTED' });
 
     const result = await getTopTracks('user-1', 10, 'short_term');
 
@@ -108,7 +108,7 @@ describe('getTopTracks', () => {
 
   it('returns API_ERROR on non-ok response', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
 
@@ -120,7 +120,7 @@ describe('getTopTracks', () => {
 
   it('returns normalized tracks on success', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
@@ -138,7 +138,7 @@ describe('getTopTracks', () => {
 
   it('defaults to short_term for unknown time range', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     let capturedUrl = '';
     vi.stubGlobal('fetch', vi.fn().mockImplementation((url: string) => {
@@ -170,7 +170,7 @@ describe('sendPlaybackCommand', () => {
 
   it('returns NOT_CONNECTED when token is unavailable', async () => {
     dbReturnsAccount(null);
-    mockGetToken.mockResolvedValue(null);
+    mockGetToken.mockResolvedValue({ ok: false, error: 'NOT_CONNECTED' });
 
     const result = await sendPlaybackCommand('user-1', 'play');
 
@@ -180,7 +180,7 @@ describe('sendPlaybackCommand', () => {
 
   it('returns ok:true for a successful play command (204)', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     // player state (no device), devices list (empty), then command succeeds
     mockFetchSequence(
@@ -195,7 +195,7 @@ describe('sendPlaybackCommand', () => {
 
   it('returns FORBIDDEN on 403', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     mockFetchSequence(
       { status: 200, ok: true, body: { device: { id: 'dev-1', name: 'PC', is_active: true } } },
@@ -210,7 +210,7 @@ describe('sendPlaybackCommand', () => {
 
   it('returns API_ERROR on generic failure', async () => {
     dbReturnsAccount({ id: 'acct-1' });
-    mockGetToken.mockResolvedValue('token');
+    mockGetToken.mockResolvedValue({ ok: true, data: 'token' });
 
     mockFetchSequence(
       { status: 200, ok: true, body: { device: { id: 'dev-1', name: 'PC', is_active: true } } },

--- a/backend/src/services/__tests__/token-refresh.service.test.ts
+++ b/backend/src/services/__tests__/token-refresh.service.test.ts
@@ -44,13 +44,13 @@ describe('getValidAccessToken', () => {
 
     const result = await getValidAccessToken(makeAccount(), refreshConfig);
 
-    expect(result).toBe('plain-access-token');
+    expect(result).toEqual({ ok: true, data: 'plain-access-token' });
     expect(mockDecrypt).toHaveBeenCalledWith('encrypted-access');
     // Should NOT call fetch when token is valid
     expect(vi.isMockFunction(global.fetch)).toBe(false);
   });
 
-  it('returns null when token is expired and no refresh token', async () => {
+  it('returns TOKEN_REFRESH_FAILED when token is expired and no refresh token', async () => {
     const account = makeAccount({
       tokenExpiresAt: new Date(Date.now() - 1000), // expired
       refreshTokenEnc: null,
@@ -58,10 +58,10 @@ describe('getValidAccessToken', () => {
 
     const result = await getValidAccessToken(account, refreshConfig);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: 'TOKEN_REFRESH_FAILED' });
   });
 
-  it('returns null when token expires within buffer and no refresh token', async () => {
+  it('returns TOKEN_REFRESH_FAILED when token expires within buffer and no refresh token', async () => {
     const account = makeAccount({
       tokenExpiresAt: new Date(Date.now() + TOKEN_REFRESH_BUFFER_MS / 2), // within buffer
       refreshTokenEnc: null,
@@ -69,7 +69,7 @@ describe('getValidAccessToken', () => {
 
     const result = await getValidAccessToken(account, refreshConfig);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: 'TOKEN_REFRESH_FAILED' });
   });
 
   it('refreshes and returns new access token when expired', async () => {
@@ -89,31 +89,44 @@ describe('getValidAccessToken', () => {
 
     const result = await getValidAccessToken(account, refreshConfig);
 
-    expect(result).toBe('new-access-token');
+    expect(result).toEqual({ ok: true, data: 'new-access-token' });
     expect(mockDecrypt).toHaveBeenCalledWith('encrypted-refresh');
     expect(mockEncrypt).toHaveBeenCalledWith('new-access-token');
     expect(mockDb.update).toHaveBeenCalledOnce();
   });
 
-  it('returns null when the refresh request fails', async () => {
+  it('returns TOKEN_REFRESH_REVOKED when provider returns 401', async () => {
     const account = makeAccount({ tokenExpiresAt: new Date(Date.now() - 5000) });
 
     mockDecrypt.mockResolvedValue('old-refresh-token');
 
-    const mockFetch = vi.fn().mockResolvedValue({ ok: false });
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
     vi.stubGlobal('fetch', mockFetch);
 
     const result = await getValidAccessToken(account, refreshConfig);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: 'TOKEN_REFRESH_REVOKED' });
   });
 
-  it('returns null when tokenExpiresAt is null', async () => {
+  it('returns TOKEN_REFRESH_NETWORK_ERROR when provider returns 5xx', async () => {
+    const account = makeAccount({ tokenExpiresAt: new Date(Date.now() - 5000) });
+
+    mockDecrypt.mockResolvedValue('old-refresh-token');
+
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await getValidAccessToken(account, refreshConfig);
+
+    expect(result).toEqual({ ok: false, error: 'TOKEN_REFRESH_NETWORK_ERROR' });
+  });
+
+  it('returns TOKEN_REFRESH_FAILED when tokenExpiresAt is null and no refresh token', async () => {
     const account = makeAccount({ tokenExpiresAt: null, refreshTokenEnc: null });
 
     const result = await getValidAccessToken(account, refreshConfig);
 
-    expect(result).toBeNull();
+    expect(result).toEqual({ ok: false, error: 'TOKEN_REFRESH_FAILED' });
   });
 
   it('passes authHeader when provided in refreshConfig', async () => {

--- a/backend/src/services/calendar.service.ts
+++ b/backend/src/services/calendar.service.ts
@@ -86,12 +86,13 @@ export async function getCalendarEvents(
 
   if (!account) return { ok: false, error: 'NOT_CONNECTED' };
 
-  const accessToken = await getValidAccessToken(account, {
+  const tokenResult = await getValidAccessToken(account, {
     tokenUrl: GOOGLE_TOKEN_URL,
     extraBody: { client_id: config.GOOGLE_CLIENT_ID ?? '', client_secret: config.GOOGLE_CLIENT_SECRET ?? '' },
   });
 
-  if (!accessToken) return { ok: false, error: 'TOKEN_REFRESH_FAILED' };
+  if (!tokenResult.ok) return { ok: false, error: tokenResult.error };
+  const accessToken = tokenResult.data;
 
   const timeMin = new Date().toISOString();
   const timeMax = new Date(Date.now() + dayCount * 24 * 60 * 60 * 1000).toISOString();

--- a/backend/src/services/oauth.service.ts
+++ b/backend/src/services/oauth.service.ts
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { z } from 'zod';
 import { eq, and } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { oauthStates, oauthAccounts } from '../db/schema.js';
@@ -129,19 +130,22 @@ export async function checkOAuthConflict(
 
 // ── Google code exchange ──────────────────────────────────────────────────
 
-interface GoogleTokenResponse {
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number;
-  scope: string;
-  error?: string;
-}
+const googleTokenSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number(),
+  scope: z.string(),
+  error: z.string().optional(),
+});
 
-interface GoogleUserInfo {
-  sub: string;
-  email: string;
-  name: string;
-}
+const googleUserInfoSchema = z.object({
+  sub: z.string(),
+  email: z.string(),
+  name: z.string().default(''),
+});
+
+type GoogleTokenResponse = z.infer<typeof googleTokenSchema>;
+type GoogleUserInfo = z.infer<typeof googleUserInfoSchema>;
 
 /**
  * Exchange a Google auth code for tokens and fetch the user's profile.
@@ -174,13 +178,18 @@ export async function exchangeGoogleCode(
     return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };
   }
 
-  const tokens = (await tokenRes.json()) as GoogleTokenResponse;
-  if (!tokens.access_token || tokens.error) return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };
+  const tokenParsed = googleTokenSchema.safeParse(await tokenRes.json());
+  if (!tokenParsed.success || !tokenParsed.data.access_token || tokenParsed.data.error) {
+    return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };
+  }
+  const tokens = tokenParsed.data;
 
   let userInfo: GoogleUserInfo;
   try {
     const infoRes = await fetch(GOOGLE_USERINFO_URL, { headers: { Authorization: `Bearer ${tokens.access_token}` } });
-    userInfo = (await infoRes.json()) as GoogleUserInfo;
+    const userInfoParsed = googleUserInfoSchema.safeParse(await infoRes.json());
+    if (!userInfoParsed.success) return { ok: false, error: 'USERINFO_FAILED' };
+    userInfo = userInfoParsed.data;
   } catch {
     return { ok: false, error: 'USERINFO_FAILED' };
   }
@@ -190,13 +199,19 @@ export async function exchangeGoogleCode(
 
 // ── Spotify code exchange ─────────────────────────────────────────────────
 
-interface SpotifyTokenResponse {
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number;
-  scope: string;
-  error?: string;
-}
+const spotifyTokenSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number(),
+  scope: z.string(),
+  error: z.string().optional(),
+});
+
+const spotifyMeSchema = z.object({
+  id: z.string(),
+});
+
+type SpotifyTokenResponse = z.infer<typeof spotifyTokenSchema>;
 
 function spotifyBasicAuth(): string {
   return `Basic ${Buffer.from(`${config.SPOTIFY_CLIENT_ID}:${config.SPOTIFY_CLIENT_SECRET}`).toString('base64')}`;
@@ -230,14 +245,18 @@ export async function exchangeSpotifyCode(
     return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };
   }
 
-  const tokens = (await tokenRes.json()) as SpotifyTokenResponse;
-  if (!tokens.access_token || tokens.error) return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };
+  const tokenParsed = spotifyTokenSchema.safeParse(await tokenRes.json());
+  if (!tokenParsed.success || !tokenParsed.data.access_token || tokenParsed.data.error) {
+    return { ok: false, error: 'TOKEN_EXCHANGE_FAILED' };
+  }
+  const tokens = tokenParsed.data;
 
   let providerUserId: string;
   try {
     const meRes = await fetch('https://api.spotify.com/v1/me', { headers: { Authorization: `Bearer ${tokens.access_token}` } });
-    const me = (await meRes.json()) as { id: string };
-    providerUserId = me.id;
+    const meParsed = spotifyMeSchema.safeParse(await meRes.json());
+    if (!meParsed.success) return { ok: false, error: 'USERINFO_FAILED' };
+    providerUserId = meParsed.data.id;
   } catch {
     return { ok: false, error: 'USERINFO_FAILED' };
   }

--- a/backend/src/services/session.service.ts
+++ b/backend/src/services/session.service.ts
@@ -33,8 +33,8 @@ export async function createSession(
     tokenHash,
     tokenLookup,
     rotatedFromId: rotatedFromId ?? null,
-    ip: meta.ip,
-    userAgent: meta.userAgent,
+    ip: sha256Hex(meta.ip),
+    userAgent: sha256Hex(meta.userAgent),
     expiresAt,
     renewalCount,
   });

--- a/backend/src/services/spotify.service.ts
+++ b/backend/src/services/spotify.service.ts
@@ -77,21 +77,23 @@ function normalizeTrack(item: RawSpotifyTrack): SpotifyTrack {
   };
 }
 
-async function getSpotifyToken(userId: string): Promise<string | null> {
+async function getSpotifyToken(userId: string): Promise<Result<string, SpotifyError>> {
   const [account] = await db
     .select()
     .from(oauthAccounts)
     .where(and(eq(oauthAccounts.userId, userId), eq(oauthAccounts.provider, 'spotify')))
     .limit(1);
 
-  if (!account) return null;
+  if (!account) return { ok: false, error: 'NOT_CONNECTED' };
 
   // PKCE (BYOA) mode: use the user's own client_id in the token body - no shared Authorization header.
   // Legacy mode: use the shared app's Basic auth header.
-  if (account.providerClientId) {
-    return getValidAccessToken(account, { tokenUrl: SPOTIFY_TOKEN_URL, pkceClientId: account.providerClientId, extraBody: {} });
-  }
-  return getValidAccessToken(account, { tokenUrl: SPOTIFY_TOKEN_URL, authHeader: spotifyBasicAuth(), extraBody: {} });
+  const tokenResult = account.providerClientId
+    ? await getValidAccessToken(account, { tokenUrl: SPOTIFY_TOKEN_URL, pkceClientId: account.providerClientId, extraBody: {} })
+    : await getValidAccessToken(account, { tokenUrl: SPOTIFY_TOKEN_URL, authHeader: spotifyBasicAuth(), extraBody: {} });
+
+  if (!tokenResult.ok) return { ok: false, error: tokenResult.error };
+  return { ok: true, data: tokenResult.data };
 }
 
 /** Resolve the best available Spotify device ID to target for playback commands. */
@@ -119,8 +121,9 @@ export async function getNowPlaying(userId: string): Promise<Result<NowPlayingRe
   const cached = nowPlayingCache.get(userId);
   if (cached && Date.now() < cached.expiresAt) return cached.data;
 
-  const token = await getSpotifyToken(userId);
-  if (!token) return { ok: false, error: 'NOT_CONNECTED' };
+  const tokenResult = await getSpotifyToken(userId);
+  if (!tokenResult.ok) return { ok: false, error: tokenResult.error };
+  const token = tokenResult.data;
 
   const res = await fetch(`${SPOTIFY_API}/me/player/currently-playing`, {
     headers: { Authorization: `Bearer ${token}` },
@@ -163,8 +166,9 @@ export async function getTopTracks(
   limit: number,
   timeRange: string,
 ): Promise<Result<SpotifyTrack[], SpotifyError>> {
-  const token = await getSpotifyToken(userId);
-  if (!token) return { ok: false, error: 'NOT_CONNECTED' };
+  const tokenResult = await getSpotifyToken(userId);
+  if (!tokenResult.ok) return { ok: false, error: tokenResult.error };
+  const token = tokenResult.data;
 
   const safeLimit = Math.min(MAX_TOP_TRACKS, Math.max(1, limit || DEFAULT_TOP_TRACKS));
   const safeRange: TimeRange = VALID_TIME_RANGES.includes(timeRange as TimeRange)
@@ -186,8 +190,9 @@ export async function sendPlaybackCommand(
   userId: string,
   command: PlaybackCommand,
 ): Promise<Result<void, SpotifyError>> {
-  const token = await getSpotifyToken(userId);
-  if (!token) return { ok: false, error: 'NOT_CONNECTED' };
+  const tokenResult = await getSpotifyToken(userId);
+  if (!tokenResult.ok) return { ok: false, error: tokenResult.error };
+  const token = tokenResult.data;
 
   const deviceId = await resolveActiveDeviceId(token);
   if (!deviceId) return { ok: false, error: 'NO_DEVICE' };

--- a/backend/src/services/token-refresh.service.ts
+++ b/backend/src/services/token-refresh.service.ts
@@ -1,10 +1,14 @@
+import { z } from 'zod';
 import { eq } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { oauthAccounts } from '../db/schema.js';
 import { decryptToken, encryptToken } from '../lib/crypto.js';
 import { TOKEN_REFRESH_BUFFER_MS } from '../types/constants.js';
+import type { Result } from '../types/auth.types.js';
+import type { OAuthError } from '../types/oauth.types.js';
 
 type OAuthAccountRow = typeof oauthAccounts.$inferSelect;
+type RefreshError = Extract<OAuthError, 'TOKEN_REFRESH_FAILED' | 'TOKEN_REFRESH_REVOKED' | 'TOKEN_REFRESH_NETWORK_ERROR'>;
 
 export interface TokenRefreshConfig {
   tokenUrl: string;
@@ -16,21 +20,30 @@ export interface TokenRefreshConfig {
   pkceClientId?: string;
 }
 
+const refreshResponseSchema = z.object({
+  access_token: z.string(),
+  expires_in: z.number(),
+});
+
 /**
  * Return a valid decrypted access token for the given account.
  * Automatically refreshes using the stored refresh token if the current one
  * expires within TOKEN_REFRESH_BUFFER_MS. Updates the DB on refresh.
- * Returns null if unable to get a valid token.
+ *
+ * Error codes:
+ * - TOKEN_REFRESH_REVOKED: provider returned 401/403 — user must re-authorize
+ * - TOKEN_REFRESH_NETWORK_ERROR: network/5xx failure — transient, safe to retry
+ * - TOKEN_REFRESH_FAILED: malformed provider response or missing refresh token
  */
 export async function getValidAccessToken(
   account: OAuthAccountRow,
   refreshConfig: TokenRefreshConfig,
-): Promise<string | null> {
+): Promise<Result<string, RefreshError>> {
   const expiresAt = account.tokenExpiresAt ? new Date(account.tokenExpiresAt) : null;
   const isStillValid = expiresAt && expiresAt.getTime() - Date.now() > TOKEN_REFRESH_BUFFER_MS;
 
-  if (isStillValid) return decryptToken(account.accessTokenEnc);
-  if (!account.refreshTokenEnc) return null;
+  if (isStillValid) return { ok: true, data: await decryptToken(account.accessTokenEnc) };
+  if (!account.refreshTokenEnc) return { ok: false, error: 'TOKEN_REFRESH_FAILED' };
 
   const refreshToken = await decryptToken(account.refreshTokenEnc);
 
@@ -41,27 +54,42 @@ export async function getValidAccessToken(
     headers['Authorization'] = refreshConfig.authHeader;
   }
 
-  const res = await fetch(refreshConfig.tokenUrl, {
-    method: 'POST',
-    headers,
-    body: new URLSearchParams({
-      grant_type: 'refresh_token',
-      refresh_token: refreshToken,
-      ...(refreshConfig.pkceClientId ? { client_id: refreshConfig.pkceClientId } : {}),
-      ...refreshConfig.extraBody,
-    }),
-  });
+  let res: Response;
+  try {
+    res = await fetch(refreshConfig.tokenUrl, {
+      method: 'POST',
+      headers,
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        ...(refreshConfig.pkceClientId ? { client_id: refreshConfig.pkceClientId } : {}),
+        ...refreshConfig.extraBody,
+      }),
+    });
+  } catch {
+    return { ok: false, error: 'TOKEN_REFRESH_NETWORK_ERROR' };
+  }
 
-  if (!res.ok) return null;
+  if (!res.ok) {
+    // 401/403 means the refresh token is revoked or expired — user must re-authorize.
+    // 5xx or other codes are transient provider errors — safe to retry later.
+    return {
+      ok: false,
+      error: res.status === 401 || res.status === 403 ? 'TOKEN_REFRESH_REVOKED' : 'TOKEN_REFRESH_NETWORK_ERROR',
+    };
+  }
 
-  const data = (await res.json()) as { access_token: string; expires_in: number };
-  const newAccessEnc = await encryptToken(data.access_token);
-  const newExpiry = new Date(Date.now() + data.expires_in * 1000);
+  const parsed = refreshResponseSchema.safeParse(await res.json());
+  if (!parsed.success) return { ok: false, error: 'TOKEN_REFRESH_FAILED' };
+
+  const { access_token, expires_in } = parsed.data;
+  const newAccessEnc = await encryptToken(access_token);
+  const newExpiry = new Date(Date.now() + expires_in * 1000);
 
   await db
     .update(oauthAccounts)
     .set({ accessTokenEnc: newAccessEnc, tokenExpiresAt: newExpiry, updatedAt: new Date() })
     .where(eq(oauthAccounts.id, account.id));
 
-  return data.access_token;
+  return { ok: true, data: access_token };
 }

--- a/backend/src/types/oauth.types.ts
+++ b/backend/src/types/oauth.types.ts
@@ -9,6 +9,10 @@ export type OAuthError =
   | 'TOKEN_EXCHANGE_FAILED'
   | 'USERINFO_FAILED'
   | 'TOKEN_REFRESH_FAILED'
+  /** Provider returned 401/403 — refresh token is revoked/expired, user must re-authorize. */
+  | 'TOKEN_REFRESH_REVOKED'
+  /** Network or 5xx error during refresh — transient, safe to retry. */
+  | 'TOKEN_REFRESH_NETWORK_ERROR'
   | 'NO_REDIRECT_URI'
   | 'API_ERROR'
   | 'FORBIDDEN';


### PR DESCRIPTION
## What
- Validate `TOKEN_ENC_KEY_BASE64` decodes to exactly 32 bytes at startup (#117)
- Restrict dev CORS to specific extension ID when `CHROME_EXTENSION_ID` env is set (#115)
- Reduce `/auth/refresh` rate limit from 30 to 5 requests per 15 minutes (#119)
- Suppress internal error details from 4xx responses in production (#118)
- Hash session IP and user-agent with SHA-256 before DB storage (#116)
- Zod validation for calendar `days` and Spotify `limit`/`time_range` query params (#112)
- Typed `Result<string, RefreshError>` return from `getValidAccessToken` with `TOKEN_REFRESH_REVOKED` and `TOKEN_REFRESH_NETWORK_ERROR` codes (#113)
- Zod validation of all OAuth provider API responses (Google token, userinfo, Spotify token, /me) (#114)

## Why
Several backend endpoints accepted untrusted input without validation, stored PII in plaintext, and leaked internal error messages to clients. The token refresh path returned an opaque `null` on failure, making it impossible for callers to distinguish a revoked token (requiring re-auth) from a transient network error (safe to retry). Provider API responses were cast with `as Type` without any runtime check, meaning a malformed upstream response could silently corrupt data or cause a runtime crash.

## How
Commits are split by domain: (A) config/CORS/rate-limit/error-handler, (B) session hashing + query-param Zod schemas, (C) token-refresh Result typing + Zod provider response validation. The `ip` column was migrated from PostgreSQL `inet` to `text` via a lossless `::text` cast so existing rows are preserved. `getValidAccessToken` callers (calendar, Spotify services) propagate the typed error codes directly to their own Result returns. All three affected unit test files were updated to assert the new Result shapes and cover the two new error codes.

## Test plan
- [ ] `npx vitest run` in `backend/` — all 13 unit test files pass, only the 2 DB-dependent e2e tests remain red (pre-existing, need local Postgres)
- [ ] `npx tsc --noEmit` in `backend/` exits 0
- [ ] Start backend with a `TOKEN_ENC_KEY_BASE64` shorter than 32 bytes → process exits with validation error
- [ ] In production mode, a 400 response body says "Invalid request", not the internal Zod message
- [ ] Rapid-fire > 5 hits to `/auth/refresh` within 15 min returns 429
- [ ] Session row in DB shows 64-char hex for `ip` and `userAgent` columns after login
- [ ] `/calendar/events?days=abc` returns 400; `?days=200` returns 400; `?days=7` returns 200
- [ ] `/spotify/top-tracks?time_range=invalid` returns 400
- [ ] Spotify connect → disconnect → reconnect: token refresh errors surface as `TOKEN_REFRESH_REVOKED` not generic null

Closes #112, #113, #114, #115, #116, #117, #118, #119

Generated by [Claude-Bot] of [@Yehuda Briskman]