### PR TITLE
feat: surface email send status on register

### DIFF
--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -50,7 +50,7 @@ export async function registerController(req: FastifyRequest, reply: FastifyRepl
   }
 
   reply.setCookie(COOKIE_NAME, result.data.rawRefreshToken, cookieOpts);
-  void reply.send({ accessToken: result.data.accessToken, refreshToken: result.data.rawRefreshToken });
+  void reply.send({ accessToken: result.data.accessToken, refreshToken: result.data.rawRefreshToken, emailSent: result.data.emailSent });
 }
 
 export async function loginController(req: FastifyRequest, reply: FastifyReply): Promise<void> {

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -13,27 +13,31 @@ import {
 } from './session.service.js';
 import { sendVerification } from './auth-email.service.js';
 import { logger } from '../lib/logger.js';
-import type { Result, TokenPair, SessionMeta, AuthError } from '../types/auth.types.js';
+import type { Result, TokenPair, RegisterResult, SessionMeta, AuthError } from '../types/auth.types.js';
 
-/** Register a new user with email + password. Returns TOKEN_PAIR or EMAIL_TAKEN. */
+/** Register a new user with email + password. Returns RegisterResult or EMAIL_TAKEN. */
 export async function register(
   email: string,
   password: string,
   name: string,
   meta: SessionMeta,
-): Promise<Result<TokenPair, AuthError>> {
+): Promise<Result<RegisterResult, AuthError>> {
   const existing = await db.select({ id: users.id }).from(users).where(eq(users.email, email)).limit(1);
   if (existing.length > 0) return { ok: false, error: 'EMAIL_TAKEN' };
 
   const passwordHash = await hashPassword(password);
   const [user] = await db.insert(users).values({ email, name, passwordHash }).returning();
 
-  // Send verification email - fire-and-forget so register doesn't fail on email errors
-  void sendVerification(user.id).catch((err) => logger.error({ err }, 'register: verification email failed'));
+  const [emailSent, accessToken, rawRefreshToken] = await Promise.all([
+    sendVerification(user.id).then(() => true).catch((err: unknown) => {
+      logger.error({ err, userId: user.id }, 'register: verification email failed');
+      return false;
+    }),
+    signAccessToken({ sub: user.id, email: user.email, name: user.name, emailVerified: false }),
+    createSession(user.id, meta),
+  ]);
 
-  const accessToken = await signAccessToken({ sub: user.id, email: user.email, name: user.name, emailVerified: false });
-  const rawRefreshToken = await createSession(user.id, meta);
-  return { ok: true, data: { accessToken, rawRefreshToken } };
+  return { ok: true, data: { accessToken, rawRefreshToken, emailSent } };
 }
 
 /** Authenticate with email + password. Returns TOKEN_PAIR or INVALID_CREDENTIALS. */

--- a/backend/src/types/auth.types.ts
+++ b/backend/src/types/auth.types.ts
@@ -28,6 +28,11 @@ export interface TokenPair {
   rawRefreshToken: string;
 }
 
+/** TokenPair extended with email delivery status, returned only by register. */
+export interface RegisterResult extends TokenPair {
+  emailSent: boolean;
+}
+
 /** User data returned by /me and stored in access token payload. */
 export interface UserRecord {
   id: string;


### PR DESCRIPTION
## What
- `register()` now returns `emailSent: boolean` alongside the token pair (#135)
- `/auth/register` response includes `emailSent` field for the extension to act on
- `RegisterResult` type added to `auth.types.ts` (extends `TokenPair`)

## Why
Registration silently swallowed email delivery failures. The caller had no signal to warn the user that their verification email was not sent, creating silent onboarding failures with no recovery path visible to the user.

## How
Changed `register()` to run `sendVerification`, `signAccessToken`, and `createSession` in parallel with `Promise.all`. Email errors are caught and logged; `emailSent: false` is returned instead of throwing. Controller passes the field through unchanged.

Note: #120 (narrow manifest host_permissions for Google OAuth) is already satisfied — `chrome.identity.launchWebAuthFlow` handles OAuth without requiring `host_permissions` entries, and the existing `https://www.google.com/*` entry serves the search redirect and favicon fetcher, not OAuth.

## Test plan
- [ ] `POST /auth/register` with valid SMTP → response includes `emailSent: true`
- [ ] `POST /auth/register` with SMTP not configured → response includes `emailSent: false`, registration still succeeds (200)
- [ ] `npx tsc --noEmit` exits 0
- [ ] CI green

Closes #135, #120

Generated by [Claude-Bot] of [@Yehuda Briskman]