### PR TITLE
perf: phase 3 backend performance optimizations

### DIFF
--- a/backend/src/controllers/calendar.controller.ts
+++ b/backend/src/controllers/calendar.controller.ts
@@ -4,15 +4,18 @@ import * as calendarService from '../services/calendar.service.js';
 
 const calendarQuerySchema = z.object({
   days: z.coerce.number().int().min(1).max(90).default(7),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+  offset: z.coerce.number().int().min(0).default(0),
 });
 
 export async function getCalendarEventsController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const parsed = calendarQuerySchema.safeParse(req.query);
   if (!parsed.success) {
-    void reply.status(400).send({ statusCode: 400, error: 'Bad Request', message: 'days must be an integer between 1 and 90' });
+    void reply.status(400).send({ statusCode: 400, error: 'Bad Request', message: parsed.error.issues[0]?.message ?? 'Invalid query params' });
     return;
   }
-  const result = await calendarService.getCalendarEvents(req.user.sub, parsed.data.days);
+  const { days, limit, offset } = parsed.data;
+  const result = await calendarService.getCalendarEvents(req.user.sub, days);
 
   if (!result.ok) {
     if (result.error === 'NOT_CONNECTED') {
@@ -23,6 +26,9 @@ export async function getCalendarEventsController(req: FastifyRequest, reply: Fa
     return;
   }
 
+  const all = result.data;
+  const page = all.slice(offset, offset + limit);
+
   reply.header('Cache-Control', 'private, max-age=60');
-  void reply.send({ events: result.data });
+  void reply.send({ events: page, total: all.length, limit, offset });
 }

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -85,16 +85,23 @@ export async function refresh(
   }
 
   logger.warn({ sessionId: session.id, renewal: session.renewalCount + 1 }, 'refresh: rotating session');
-  await revokeSession(session.id);
 
-  const [user] = await db.select().from(users).where(eq(users.id, session.userId)).limit(1);
+  // Revoke old session and fetch user in parallel — both are independent at this point.
+  const [[user]] = await Promise.all([
+    db.select({ id: users.id, email: users.email, name: users.name, emailVerified: users.emailVerified })
+      .from(users).where(eq(users.id, session.userId)).limit(1),
+    revokeSession(session.id),
+  ]);
+
   if (!user) {
     logger.error({ userId: session.userId }, 'refresh: USER_NOT_FOUND');
     return { ok: false, error: 'USER_NOT_FOUND' };
   }
 
-  const accessToken = await signAccessToken({ sub: user.id, email: user.email, name: user.name, emailVerified: user.emailVerified });
-  const rawRefreshToken = await createSession(user.id, meta, session.id, session.renewalCount + 1);
+  const [accessToken, rawRefreshToken] = await Promise.all([
+    signAccessToken({ sub: user.id, email: user.email, name: user.name, emailVerified: user.emailVerified }),
+    createSession(user.id, meta, session.id, session.renewalCount + 1),
+  ]);
   logger.warn({ userId: user.id }, 'refresh: new session created');
   return { ok: true, data: { accessToken, rawRefreshToken } };
 }

--- a/backend/src/services/token-refresh.service.ts
+++ b/backend/src/services/token-refresh.service.ts
@@ -25,6 +25,10 @@ const refreshResponseSchema = z.object({
   expires_in: z.number(),
 });
 
+// Deduplicates concurrent refresh calls for the same account — the second caller
+// awaits the first refresh rather than triggering a parallel token rotation race.
+const inflight = new Map<string, Promise<Result<string, RefreshError>>>();
+
 /**
  * Return a valid decrypted access token for the given account.
  * Automatically refreshes using the stored refresh token if the current one
@@ -35,14 +39,10 @@ const refreshResponseSchema = z.object({
  * - TOKEN_REFRESH_NETWORK_ERROR: network/5xx failure — transient, safe to retry
  * - TOKEN_REFRESH_FAILED: malformed provider response or missing refresh token
  */
-export async function getValidAccessToken(
+async function doRefresh(
   account: OAuthAccountRow,
   refreshConfig: TokenRefreshConfig,
 ): Promise<Result<string, RefreshError>> {
-  const expiresAt = account.tokenExpiresAt ? new Date(account.tokenExpiresAt) : null;
-  const isStillValid = expiresAt && expiresAt.getTime() - Date.now() > TOKEN_REFRESH_BUFFER_MS;
-
-  if (isStillValid) return { ok: true, data: await decryptToken(account.accessTokenEnc) };
   if (!account.refreshTokenEnc) return { ok: false, error: 'TOKEN_REFRESH_FAILED' };
 
   const refreshToken = await decryptToken(account.refreshTokenEnc);
@@ -92,4 +92,27 @@ export async function getValidAccessToken(
     .where(eq(oauthAccounts.id, account.id));
 
   return { ok: true, data: access_token };
+}
+
+/**
+ * Return a valid decrypted access token for the given account.
+ * Automatically refreshes using the stored refresh token if the current one
+ * expires within TOKEN_REFRESH_BUFFER_MS. Updates the DB on refresh.
+ * Concurrent calls for the same account share a single in-flight refresh promise.
+ */
+export async function getValidAccessToken(
+  account: OAuthAccountRow,
+  refreshConfig: TokenRefreshConfig,
+): Promise<Result<string, RefreshError>> {
+  const expiresAt = account.tokenExpiresAt ? new Date(account.tokenExpiresAt) : null;
+  const isStillValid = expiresAt && expiresAt.getTime() - Date.now() > TOKEN_REFRESH_BUFFER_MS;
+
+  if (isStillValid) return { ok: true, data: await decryptToken(account.accessTokenEnc) };
+
+  const existing = inflight.get(account.id);
+  if (existing) return existing;
+
+  const promise = doRefresh(account, refreshConfig).finally(() => inflight.delete(account.id));
+  inflight.set(account.id, promise);
+  return promise;
 }

--- a/backend/src/types/constants.ts
+++ b/backend/src/types/constants.ts
@@ -11,8 +11,9 @@ export const REFRESH_WINDOW_DAYS = 7;
  */
 export const MAX_RENEWALS = 2016;
 
-/** bcrypt rounds for password and token hashing. */
-export const BCRYPT_ROUNDS = 10;
+/** bcrypt rounds for session token hashing. Tokens are random 48-byte values so 2^384
+ *  brute-force is already infeasible — work factor only needs to slow direct DB leaks. */
+export const BCRYPT_ROUNDS = 6;
 
 /** Access token lifetime passed to jose. */
 export const ACCESS_TOKEN_TTL = '15m';


### PR DESCRIPTION
## What
- Reduce session token bcrypt work factor from 10 → 6 rounds (#121)
- Parallelize `revokeSession` + user `SELECT` + `signAccessToken` + `createSession` in the refresh handler (#122)
- Add in-flight promise cache to `getValidAccessToken` to deduplicate concurrent refresh calls per account (#126)
- Add `limit` + `offset` pagination to `GET /calendar/events` with `total` in response (#128)

## Why
Session tokens are cryptographically random 48-byte values — their search space (2^384) makes brute force impossible regardless of bcrypt work factor. The bcrypt cost was wasted. The refresh handler's sequential DB operations added unnecessary latency on every token rotation. Under concurrent requests (calendar + Spotify loading simultaneously), two parallel refresh calls could race and one would invalidate the other's newly-issued token. The calendar endpoint had no pagination, risking large responses for users with many events.

## How
`BCRYPT_ROUNDS` constant lowered to 6 (passwords have their own hardcoded 12 in `password.ts`, unaffected). `refresh()` now runs revoke+user fetch and sign+createSession in two parallel `Promise.all` batches. `getValidAccessToken` uses a module-level `Map<accountId, Promise>` — the second concurrent caller gets the same promise and both resolve together when the single refresh completes. Calendar controller slices the already-fetched event array server-side and adds `total`, `limit`, `offset` to the response.

## Test plan
- [ ] `npx tsc --noEmit` exits 0 in `backend/`
- [ ] 13 unit test files pass (`npx vitest run`)
- [ ] Login + refresh round-trip still works end-to-end
- [ ] `/calendar/events?limit=5&offset=0` returns 5 events + `total` count
- [ ] Two simultaneous calendar + Spotify requests don't cause token refresh race

Closes #121, #122, #126, #128

Generated by [Claude-Bot] of [@Yehuda Briskman]