### PR TITLE
perf: debounce calendar fetch and add per-section settings hook

### DIFF
--- a/web/src/contexts/SettingsContext.tsx
+++ b/web/src/contexts/SettingsContext.tsx
@@ -1,9 +1,30 @@
-import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useRef, useSyncExternalStore, type ReactNode } from 'react';
 import { syncStorage, localStore } from '../lib/chrome-storage';
 import { type Settings, defaultSettings } from '../types/settings';
 import { migrateFlatToSectioned, isLegacySettings } from '../lib/migrateSettings';
 import { getAccessToken, apiGet, apiPut } from '../lib/api';
 
+// ── External store for per-section subscriptions ──────────────────────────
+// Holds a mutable snapshot of the current settings so useSyncExternalStore
+// consumers can subscribe to individual sections without re-rendering on
+// unrelated section changes. The Provider updates this alongside its own
+// useState so both stay in sync.
+
+type StoreListener = () => void;
+const storeListeners = new Set<StoreListener>();
+let storeSnapshot: Settings = { ...defaultSettings };
+
+function subscribeToStore(listener: StoreListener): () => void {
+  storeListeners.add(listener);
+  return () => storeListeners.delete(listener);
+}
+
+function notifyStore(next: Settings): void {
+  storeSnapshot = next;
+  for (const l of storeListeners) l();
+}
+
+// ── Settings sections excluded from backend sync ───────────────────────────
 // Sections excluded from backend sync (ephemeral / device-specific state)
 const SYNC_EXCLUDE = new Set<keyof Settings>(['focus']);
 
@@ -45,8 +66,17 @@ interface SettingsContextValue {
 export const SettingsContext = createContext<SettingsContextValue | null>(null);
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
-  const [settings, setSettings] = useState<Settings>({ ...defaultSettings });
+  const [settings, setSettingsRaw] = useState<Settings>({ ...defaultSettings });
   const [loaded, setLoaded] = useState(false);
+
+  // Wrap the setter so the external store is always updated in the same tick.
+  const setSettings = useCallback((next: Settings | ((prev: Settings) => Settings)) => {
+    setSettingsRaw((prev) => {
+      const resolved = typeof next === 'function' ? next(prev) : next;
+      notifyStore(resolved);
+      return resolved;
+    });
+  }, []);
   const pushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingDeltaRef = useRef<Partial<Settings>>({});
   const settingsRef = useRef<Settings>({ ...defaultSettings });
@@ -314,4 +344,16 @@ export function useSettings() {
   const ctx = useContext(SettingsContext);
   if (!ctx) throw new Error('useSettings must be used within SettingsProvider');
   return ctx;
+}
+
+/**
+ * Subscribe to a single settings section. Only re-renders when that section's
+ * object reference changes — unrelated section updates are invisible to this hook.
+ * Use instead of `useSettings().settings[section]` in performance-sensitive components.
+ */
+export function useSettingsSection<S extends keyof Settings>(section: S): Settings[S] {
+  return useSyncExternalStore(
+    subscribeToStore,
+    () => storeSnapshot[section],
+  );
 }

--- a/web/src/hooks/useCalendar.ts
+++ b/web/src/hooks/useCalendar.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { syncStorage } from '../lib/chrome-storage';
 import { apiGet } from '../lib/api';
 import { useSettings } from '../contexts/SettingsContext';
@@ -10,18 +10,30 @@ export function useCalendar() {
   const calendarDays = settings.integrations.calendar.days;
   const [events, setEvents] = useState<CalendarEvent[]>([]);
 
-  // Load events - from backend if connected, otherwise from local storage
+  const fetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Load events - from backend if connected, otherwise from local storage.
+  // calendarDays changes are debounced 500ms so rapid setting adjustments
+  // don't fire multiple API calls.
   useEffect(() => {
-    if (calendarConnected) {
+    if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
+
+    if (!calendarConnected) {
+      syncStorage.get<CalendarEvent[]>('localEvents', []).then(setEvents);
+      return;
+    }
+
+    fetchTimerRef.current = setTimeout(() => {
       apiGet<{ events: CalendarEvent[] }>(`/calendar/events?days=${calendarDays}`)
         .then((data) => setEvents(data.events))
         .catch(() => {
-          // Fall back to local events on error
           syncStorage.get<CalendarEvent[]>('localEvents', []).then(setEvents);
         });
-    } else {
-      syncStorage.get<CalendarEvent[]>('localEvents', []).then(setEvents);
-    }
+    }, 500);
+
+    return () => {
+      if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);
+    };
   }, [calendarConnected, calendarDays]);
 
   // Cross-tab sync for local events


### PR DESCRIPTION
## What
- Debounce calendar re-fetch by 500ms when `calendarDays` setting changes (#127)
- Add `useSettingsSection<S>(section)` hook powered by `useSyncExternalStore` so components only re-render when their section changes (#125)

## Why
Changing the calendar days slider fired a fresh API call on every intermediate value, wasting requests and causing visible flicker. Every settings change — even to an unrelated section like clock or weather — caused all `useSettings()` consumers to re-render because the entire `settings` object reference changed each time.

## How
`useCalendar` now uses a `setTimeout`/`clearTimeout` debounce pattern (500ms) inside a `useEffect` with proper cleanup. The `SettingsContext` introduces a module-level store (`storeSnapshot` + `storeListeners`) that is updated inside a `setSettings` wrapper, keeping the store in sync with React state at all times. `useSettingsSection` subscribes to the store via React's `useSyncExternalStore` and returns only the requested section's value — since section objects get new references only when they actually change, unrelated section updates produce no re-render. Existing `useSettings()` callers are unaffected.

## Test plan
- [ ] `npx tsc --noEmit` exits 0 in `web/`
- [ ] Drag the calendar days slider rapidly — only one API call fires after settling
- [ ] Change clock settings → weather widget does not re-render (verify with React DevTools Profiler)
- [ ] Change weather settings → calendar section does not re-render
- [ ] `useSettingsSection('clock')` returns up-to-date value after `update('clock', patch)` call

Closes #125, #127

Generated by [Claude-Bot] of [@Yehuda Briskman]