### PR TITLE
fix: Phase 4 — extension polish and fixes

### DIFF
--- a/web/src/background/index.ts
+++ b/web/src/background/index.ts
@@ -1,6 +1,10 @@
 /** Background service worker - manages tab state and broadcasts to content scripts */
 
+let suspended = false;
+chrome.runtime.onSuspend.addListener(() => { suspended = true; });
+
 async function broadcastTabsChanged() {
+  if (suspended) return;
   const tabs = await chrome.tabs.query({});
   await chrome.storage.local.set({ _windom_tabs: tabs });
 

--- a/web/src/components/AppLoader.tsx
+++ b/web/src/components/AppLoader.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useBackgroundContext } from '../contexts/BackgroundContext';
 import { DEFAULT_GRADIENT } from '../lib/background-constants';
+import { LOADER_FADE_DURATION_MS } from '../lib/timing-constants';
 
 export function AppLoader() {
   const { backgroundReady } = useBackgroundContext();
@@ -9,7 +10,7 @@ export function AppLoader() {
   useEffect(() => {
     if (!backgroundReady) return;
     // Wait for the CSS fade-out to finish before unmounting
-    const id = setTimeout(() => setHidden(true), 600);
+    const id = setTimeout(() => setHidden(true), LOADER_FADE_DURATION_MS);
     return () => clearTimeout(id);
   }, [backgroundReady]);
 

--- a/web/src/components/links/DockBar.tsx
+++ b/web/src/components/links/DockBar.tsx
@@ -144,7 +144,7 @@ export function DockBar() {
             onClick={(e) => e.stopPropagation()}
             onSubmit={handleSubmit}
           >
-            <button type="button" className="dock-form-close" onClick={handleClose}>
+            <button type="button" className="dock-form-close" onClick={handleClose} aria-label="Close">
               <X size={16} />
             </button>
             <input

--- a/web/src/components/search/SearchOverlay.tsx
+++ b/web/src/components/search/SearchOverlay.tsx
@@ -2,6 +2,12 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Search, Globe, Clock, LayoutGrid, ChevronDown, Terminal, Plus, X, RotateCcw, Copy, Pin, ExternalLink, type LucideIcon } from 'lucide-react';
 import { useSettings } from '../../contexts/SettingsContext';
 import type { GeneralSettings } from '../../types/settings';
+import {
+  OVERLAY_OPEN_FOCUS_DELAY_MS,
+  OVERLAY_CLOSE_RESET_DELAY_MS,
+  SUGGESTIONS_DEBOUNCE_MS,
+  SEARCH_API_TIMEOUT_MS,
+} from '../../lib/timing-constants';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -192,7 +198,7 @@ async function getSearchSuggestions(q: string): Promise<Suggestion[]> {
   try {
     const res = await fetch(
       `https://duckduckgo.com/ac/?q=${encodeURIComponent(q)}&type=list`,
-      { signal: AbortSignal.timeout(2000) },
+      { signal: AbortSignal.timeout(SEARCH_API_TIMEOUT_MS) },
     );
     const data = await res.json() as unknown;
 
@@ -284,7 +290,7 @@ export function SearchOverlay() {
   // Auto-focus when opened; delay state reset so exit animation plays fully
   useEffect(() => {
     if (open) {
-      setTimeout(() => inputRef.current?.focus(), 30);
+      setTimeout(() => inputRef.current?.focus(), OVERLAY_OPEN_FOCUS_DELAY_MS);
     } else {
       const timer = setTimeout(() => {
         setValue('');
@@ -292,7 +298,7 @@ export function SearchOverlay() {
         setActiveIdx(-1);
         setDropdownOpen(false);
         setEnginePickerOpen(false);
-      }, 300);
+      }, OVERLAY_CLOSE_RESET_DELAY_MS);
       return () => clearTimeout(timer);
     }
   }, [open]);
@@ -314,7 +320,7 @@ export function SearchOverlay() {
       ]);
       setSuggestions([...tabs, ...history, ...searches]);
       setActiveIdx(-1);
-    }, 180);
+    }, SUGGESTIONS_DEBOUNCE_MS);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };

--- a/web/src/components/search/SearchOverlay.tsx
+++ b/web/src/components/search/SearchOverlay.tsx
@@ -369,6 +369,12 @@ export function SearchOverlay() {
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        inputRef.current?.focus();
+        return;
+      }
+
       if (e.key === 'Escape') {
         if (dropdownOpen) { setDropdownOpen(false); setActiveIdx(-1); }
         else setOpen(false);
@@ -415,7 +421,7 @@ export function SearchOverlay() {
         if (e.target === e.currentTarget) setOpen(false);
       }}
     >
-      <div className="search-overlay-box">
+      <div className="search-overlay-box" role="dialog" aria-label="Search" onKeyDown={handleKeyDown}>
         <div className={`search-overlay-input-row${showDropdown ? ' dropdown-open' : ''}${isCommandMode ? ' command-mode' : ''}`}>
           <span className="search-bar-icon">
             {isCommandMode

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -93,15 +93,17 @@ export function SettingsPanel() {
             </div>
           </div>
 
-          <span
+          <button
+            type="button"
             onClick={(e) => {
               e.stopPropagation();
               close();
             }}
             className="settings-close"
+            aria-label="Close settings"
           >
             <X size={18} />
-          </span>
+          </button>
         </div>
       </div>
     </>

--- a/web/src/components/settings/sections/AccountSettings.tsx
+++ b/web/src/components/settings/sections/AccountSettings.tsx
@@ -4,6 +4,7 @@ import { useSettings } from '../../../contexts/SettingsContext';
 import { LoginScreen } from '../../auth/LoginScreen';
 import { apiPost, apiPatch, apiFetch } from '../../../lib/api';
 import { mapOAuthError } from '../../../lib/oauth-errors';
+import { NAME_SAVE_MSG_DURATION_MS, PW_SAVE_MSG_DURATION_MS } from '../../../lib/timing-constants';
 
 // ── Signed-out view ────────────────────────────────────────────────────────
 
@@ -148,7 +149,7 @@ function ProfileSection() {
       await updateSetting('general', { userName: updated.name });
       setName(updated.name);
       setNameMsg('Saved');
-      setTimeout(() => setNameMsg(''), 2000);
+      setTimeout(() => setNameMsg(''), NAME_SAVE_MSG_DURATION_MS);
     } catch (err) {
       setNameMsg(err instanceof Error ? err.message : 'Failed to save');
     } finally {
@@ -167,7 +168,7 @@ function ProfileSection() {
       await apiPatch('/me', { currentPassword: currentPw, newPassword: newPw });
       setCurrentPw(''); setNewPw(''); setConfirmPw('');
       setPwMsg('Password updated');
-      setTimeout(() => setPwMsg(''), 3000);
+      setTimeout(() => setPwMsg(''), PW_SAVE_MSG_DURATION_MS);
     } catch (err) {
       setPwError(err instanceof Error ? err.message : 'Failed to update password');
     } finally {

--- a/web/src/components/settings/sections/AccountSettings.tsx
+++ b/web/src/components/settings/sections/AccountSettings.tsx
@@ -181,14 +181,14 @@ function ProfileSection() {
       <label className="settings-label">Profile</label>
 
       {/* Display name */}
-      <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px' }}>
+      <div className="settings-row-with-btn">
         <input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
           placeholder="Your name"
           className="settings-input"
-          style={{ fontFamily: 'inherit', fontSize: '14px', flex: 1 }}
+          style={{ flex: 1 }}
           onKeyDown={(e) => e.key === 'Enter' && handleNameSave()}
         />
         <button
@@ -208,7 +208,7 @@ function ProfileSection() {
 
       {/* Change password (only for password accounts) */}
       {user?.hasPassword && (
-        <div style={{ marginTop: '12px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <div className="settings-section-mt" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <label className="settings-hint" style={{ marginBottom: '2px' }}>Change password</label>
           <input
             type="password"
@@ -217,7 +217,6 @@ function ProfileSection() {
             onChange={(e) => { setCurrentPw(e.target.value); setPwError(''); }}
             autoComplete="current-password"
             className="settings-input"
-            style={{ fontFamily: 'inherit', fontSize: '14px' }}
           />
           <input
             type="password"
@@ -226,7 +225,6 @@ function ProfileSection() {
             onChange={(e) => { setNewPw(e.target.value); setPwError(''); }}
             autoComplete="new-password"
             className="settings-input"
-            style={{ fontFamily: 'inherit', fontSize: '14px' }}
           />
           <input
             type="password"
@@ -235,7 +233,6 @@ function ProfileSection() {
             onChange={(e) => { setConfirmPw(e.target.value); setPwError(''); }}
             autoComplete="new-password"
             className="settings-input"
-            style={{ fontFamily: 'inherit', fontSize: '14px' }}
           />
           {pwError && <p className="auth-field-error">{pwError}</p>}
           {pwMsg && <p className="auth-field-success">{pwMsg}</p>}

--- a/web/src/components/settings/sections/AccountSettings.tsx
+++ b/web/src/components/settings/sections/AccountSettings.tsx
@@ -136,6 +136,7 @@ function ProfileSection() {
   const [pwError, setPwError] = useState('');
 
   async function handleNameSave() {
+    if (nameSaving) return;
     const trimmed = name.trim();
     if (!trimmed || trimmed === user?.name) return;
     if (trimmed.length > 100) { setNameMsg('Name must be 100 characters or less'); return; }
@@ -156,6 +157,7 @@ function ProfileSection() {
   }
 
   async function handlePasswordSave() {
+    if (pwSaving) return;
     setPwError('');
     setPwMsg('');
     if (newPw.length < 8) { setPwError('New password must be at least 8 characters'); return; }

--- a/web/src/components/settings/sections/BackgroundSettings.tsx
+++ b/web/src/components/settings/sections/BackgroundSettings.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Upload } from 'lucide-react';
 import { useSettings } from '../../../contexts/SettingsContext';
 import { useBackgroundContext } from '../../../contexts/BackgroundContext';
@@ -12,6 +13,7 @@ export function BackgroundSettings() {
   const { settings, update } = useSettings();
   const { addLocalPhoto, setFromPhoto, setUploadedBackground, photoHistory } = useBackgroundContext();
   const { unsplashHistory, localHistory, liked, toggleLike, deleteLocalPhoto } = photoHistory;
+  const [uploading, setUploading] = useState(false);
 
   const unsplashLiked = liked.filter((p) => p.source === 'unsplash' || !p.source);
   const localLiked = liked.filter((p) => p.source === 'local');
@@ -29,6 +31,7 @@ export function BackgroundSettings() {
       showSettingsMessage(`Image too large. Maximum size is ${MAX_UPLOAD_BYTES / (1024 * 1024)}MB`, 'error');
       return;
     }
+    setUploading(true);
     const reader = new FileReader();
     reader.onload = async (ev) => {
       const dataUrl = ev.target?.result as string;
@@ -49,13 +52,14 @@ export function BackgroundSettings() {
           const thumbDataUrl = canvas.toDataURL('image/jpeg', 0.75);
           addLocalPhoto(dataUrl, thumbDataUrl, file.name);
         }
+        setUploading(false);
       };
       img.src = dataUrl;
 
       await update('background', { source: 'local' });
       showSettingsMessage('Background image uploaded successfully', 'success');
     };
-    reader.onerror = () => showSettingsMessage('Error reading image file', 'error');
+    reader.onerror = () => { setUploading(false); showSettingsMessage('Error reading image file', 'error'); };
     reader.readAsDataURL(file);
   };
 
@@ -127,11 +131,12 @@ export function BackgroundSettings() {
           <div className="settings-group">
             <div className="upload-row">
               <span className="settings-label" style={{ margin: 0 }}>Upload local background</span>
-              <label className="upload-circle-btn" title="Choose image">
+              <label className={`upload-circle-btn${uploading ? ' uploading' : ''}`} title={uploading ? 'Uploading…' : 'Choose image'}>
                 <Upload size={15} />
-                <input type="file" accept="image/*" onChange={handleUpload} style={{ display: 'none' }} />
+                <input type="file" accept="image/*" onChange={handleUpload} disabled={uploading} style={{ display: 'none' }} />
               </label>
             </div>
+            {uploading && <p className="settings-hint">Uploading…</p>}
           </div>
 
           <section style={{ marginTop: 24, marginBottom: 28 }}>

--- a/web/src/components/settings/sections/BackgroundSettings.tsx
+++ b/web/src/components/settings/sections/BackgroundSettings.tsx
@@ -109,7 +109,7 @@ export function BackgroundSettings() {
             <small className="settings-hint">Leave empty for random nature photos</small>
           </div>
 
-          <section style={{ marginTop: 24 }}>
+          <section className="settings-section-mt-lg">
             <h3 className="settings-section-heading">Unsplash Photos</h3>
             {unsplashLiked.length > 0 && (
               <div className="settings-group">
@@ -139,7 +139,7 @@ export function BackgroundSettings() {
             {uploading && <p className="settings-hint">Uploading…</p>}
           </div>
 
-          <section style={{ marginTop: 24, marginBottom: 28 }}>
+          <section className="settings-section-mt-lg" style={{ marginBottom: 28 }}>
             <h3 className="settings-section-heading">Built-in</h3>
             <div className="settings-group">
               <PhotoGrid photos={BUNDLED_PHOTOS} onLike={() => {}} onSelect={setFromPhoto} />

--- a/web/src/components/settings/sections/LinksSettings.tsx
+++ b/web/src/components/settings/sections/LinksSettings.tsx
@@ -53,6 +53,7 @@ export function LinksSettings() {
                 type="button"
                 onClick={() => removeLink(i)}
                 className="link-remove-btn"
+                aria-label="Remove link"
               >
                 &times;
               </button>

--- a/web/src/components/settings/sections/SpotifySettings.tsx
+++ b/web/src/components/settings/sections/SpotifySettings.tsx
@@ -88,6 +88,7 @@ function NoClientIdState({ onSaved }: { onSaved: () => void }) {
   }
 
   async function handleSaveAndConnect() {
+    if (busy) return;
     const trimmed = clientIdInput.trim();
     if (!trimmed) return;
     setBusy(true);
@@ -197,6 +198,7 @@ function SavedNotConnectedState({ clientId, onConnected, onChangeApp }: { client
   const [error, setError] = useState('');
 
   async function handleConnect() {
+    if (busy) return;
     setBusy(true);
     setError('');
     try {
@@ -262,6 +264,7 @@ function ConnectedState({ clientId, onDisconnected }: { clientId: string; onDisc
   const [error, setError] = useState('');
 
   async function handleDisconnect() {
+    if (busy) return;
     setBusy(true);
     setError('');
     try {

--- a/web/src/components/settings/sections/SpotifySettings.tsx
+++ b/web/src/components/settings/sections/SpotifySettings.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '../../../contexts/AuthContext';
 import { apiPost, apiFetch } from '../../../lib/api';
 import { mapOAuthError } from '../../../lib/oauth-errors';
 import { generateCodeVerifier, generateCodeChallenge } from '../../../lib/pkce';
+import { COPY_CONFIRM_DURATION_MS } from '../../../lib/timing-constants';
 
 const CLIENT_ID_KEY = 'windom_spotify_client_id';
 
@@ -84,7 +85,7 @@ function NoClientIdState({ onSaved }: { onSaved: () => void }) {
   async function handleCopy() {
     await navigator.clipboard.writeText(redirectUri);
     setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    setTimeout(() => setCopied(false), COPY_CONFIRM_DURATION_MS);
   }
 
   async function handleSaveAndConnect() {

--- a/web/src/components/settings/sections/SpotifySettings.tsx
+++ b/web/src/components/settings/sections/SpotifySettings.tsx
@@ -139,7 +139,7 @@ function NoClientIdState({ onSaved }: { onSaved: () => void }) {
           <li>In your app settings, add this Redirect URI:</li>
         </ol>
 
-        <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '16px' }}>
+        <div className="settings-row-with-btn" style={{ marginBottom: '16px' }}>
           <input
             type="text"
             readOnly
@@ -169,7 +169,7 @@ function NoClientIdState({ onSaved }: { onSaved: () => void }) {
           onChange={(e) => { setClientIdInput(e.target.value); setError(''); }}
           className="settings-input"
           style={{ marginBottom: '8px', fontFamily: 'monospace', fontSize: '13px' }}
-          onKeyDown={(e) => e.key === 'Enter' && handleSaveAndConnect()}
+          onKeyDown={(e) => { if (e.key === 'Enter') handleSaveAndConnect(); }}
         />
         {error && <p className="auth-field-error" style={{ marginBottom: '8px' }}>{error}</p>}
         <button

--- a/web/src/components/settings/sections/WeatherSettings.tsx
+++ b/web/src/components/settings/sections/WeatherSettings.tsx
@@ -13,6 +13,7 @@ export function WeatherSettings() {
   const [query, setQuery] = useState(settings.weather.location);
   const [results, setResults] = useState<GeoResult[]>([]);
   const [open, setOpen] = useState(false);
+  const [searching, setSearching] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>();
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -22,6 +23,7 @@ export function WeatherSettings() {
       setOpen(false);
       return;
     }
+    setSearching(true);
     try {
       const res = await fetch(
         `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(value)}&count=6&language=en&format=json`
@@ -31,6 +33,8 @@ export function WeatherSettings() {
       setOpen(true);
     } catch {
       setResults([]);
+    } finally {
+      setSearching(false);
     }
   }, []);
 
@@ -86,6 +90,7 @@ export function WeatherSettings() {
           className="settings-input glass-input"
           autoComplete="off"
         />
+        {searching && <p className="settings-hint">Searching…</p>}
         {open && results.length > 0 && (
           <div className="city-dropdown">
             {results.map((r) => (

--- a/web/src/components/sidebar/TodoItem.tsx
+++ b/web/src/components/sidebar/TodoItem.tsx
@@ -18,12 +18,14 @@ export function TodoItem({ todo, onToggle, onRemove }: TodoItemProps) {
       <span className={`todo-item-text ${todo.completed ? 'completed' : ''}`}>
         {todo.text}
       </span>
-      <span
+      <button
+        type="button"
         onClick={() => onRemove(todo.id)}
         className="todo-item-remove"
+        aria-label="Remove todo"
       >
         <X size={14} />
-      </span>
+      </button>
     </div>
   );
 }

--- a/web/src/content/index.tsx
+++ b/web/src/content/index.tsx
@@ -38,6 +38,7 @@ dirObserver.observe(document.documentElement, { attributes: true, attributeFilte
 if (document.body) {
   dirObserver.observe(document.body, { attributes: true, attributeFilter: ['dir'] });
 }
+window.addEventListener('pagehide', () => dirObserver.disconnect());
 
 shadow.appendChild(container);
 

--- a/web/src/contexts/BackgroundContext.tsx
+++ b/web/src/contexts/BackgroundContext.tsx
@@ -215,12 +215,12 @@ export function BackgroundProvider({ children }: { children: ReactNode }) {
   }, [settings.background.source, loadUnsplash, loadLocal]);
 
   useEffect(() => {
-    if (settings.background.source === 'local') {
-      loadLocal();
-    } else {
-      loadUnsplash();
-    }
-  }, [settings.background.source, loadUnsplash, loadLocal]);
+    if (settings.background.source === 'local') loadLocal();
+  }, [settings.background.source, loadLocal]);
+
+  useEffect(() => {
+    if (settings.background.source !== 'local') loadUnsplash();
+  }, [settings.background.source, loadUnsplash]);
 
   return (
     <BackgroundContext.Provider value={{

--- a/web/src/hooks/useCalendar.ts
+++ b/web/src/hooks/useCalendar.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { syncStorage } from '../lib/chrome-storage';
 import { apiGet } from '../lib/api';
 import { useSettings } from '../contexts/SettingsContext';
+import { CALENDAR_FETCH_DEBOUNCE_MS } from '../lib/timing-constants';
 import type { CalendarEvent } from '../types/calendar';
 
 export function useCalendar() {
@@ -30,7 +31,7 @@ export function useCalendar() {
           console.warn('[calendar] Fetch failed, using cached:', err);
           syncStorage.get<CalendarEvent[]>('localEvents', []).then(setEvents);
         });
-    }, 500);
+    }, CALENDAR_FETCH_DEBOUNCE_MS);
 
     return () => {
       if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current);

--- a/web/src/hooks/useCalendar.ts
+++ b/web/src/hooks/useCalendar.ts
@@ -26,7 +26,8 @@ export function useCalendar() {
     fetchTimerRef.current = setTimeout(() => {
       apiGet<{ events: CalendarEvent[] }>(`/calendar/events?days=${calendarDays}`)
         .then((data) => setEvents(data.events))
-        .catch(() => {
+        .catch((err) => {
+          console.warn('[calendar] Fetch failed, using cached:', err);
           syncStorage.get<CalendarEvent[]>('localEvents', []).then(setEvents);
         });
     }, 500);

--- a/web/src/hooks/useClock.ts
+++ b/web/src/hooks/useClock.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
 import { formatClock } from '../utils/time';
+import { CLOCK_UPDATE_INTERVAL_MS } from '../lib/timing-constants';
 
 export function useClock() {
   const { settings } = useSettings();
@@ -13,7 +14,7 @@ export function useClock() {
   useEffect(() => {
     const tick = () => setClock(formatClock(new Date(), use24h, showSeconds, leadingZero));
     tick();
-    const id = setInterval(tick, 1000);
+    const id = setInterval(tick, CLOCK_UPDATE_INTERVAL_MS);
     return () => clearInterval(id);
   }, [use24h, showSeconds, leadingZero]);
 

--- a/web/src/hooks/useGreeting.ts
+++ b/web/src/hooks/useGreeting.ts
@@ -1,11 +1,12 @@
 import { useState, useEffect } from 'react';
 import { getGreeting } from '../utils/time';
+import { GREETING_UPDATE_INTERVAL_MS } from '../lib/timing-constants';
 
 export function useGreeting() {
   const [greeting, setGreeting] = useState(getGreeting);
 
   useEffect(() => {
-    const id = setInterval(() => setGreeting(getGreeting()), 60_000);
+    const id = setInterval(() => setGreeting(getGreeting()), GREETING_UPDATE_INTERVAL_MS);
     return () => clearInterval(id);
   }, []);
 

--- a/web/src/hooks/useLocation.ts
+++ b/web/src/hooks/useLocation.ts
@@ -35,7 +35,8 @@ async function getLocationFromIp(): Promise<LocationCoords | null> {
       return { lat: data.latitude, lon: data.longitude };
     }
     return null;
-  } catch {
+  } catch (err) {
+    console.warn('[location] IP fallback failed:', err);
     return null;
   }
 }
@@ -47,7 +48,9 @@ export function useLocation() {
       const coords = await getCoordinates();
       await ls.set('lastKnownLocation', { ...coords, timestamp: Date.now() });
       return coords;
-    } catch { /* fall through */ }
+    } catch (err) {
+      console.warn('[location] Geolocation failed, falling through:', err);
+    }
 
     // 2. Fallback to cached coords (within 24h)
     const cached = await ls.get<CachedLocation | null>('lastKnownLocation', null);

--- a/web/src/hooks/useQuotes.ts
+++ b/web/src/hooks/useQuotes.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useSettings } from '../contexts/SettingsContext';
 import { syncStorage } from '../lib/chrome-storage';
 import { hashCode } from '../utils/hash';
+import { QUOTE_FADE_DURATION_MS } from '../lib/timing-constants';
 import type { Quote, DailyQuoteCache } from '../types/quotes';
 
 const FALLBACK_QUOTES: Quote[] = [
@@ -69,7 +70,7 @@ export function useQuotes() {
     setTimeout(() => {
       setQuote(nextQuote);
       setFading(false);
-    }, 300);
+    }, QUOTE_FADE_DURATION_MS);
   }, [settings.widgets.quoteSource, fetchAPIQuote, loadLocalQuotes, getDailyQuote]);
 
   const refresh = useCallback(async () => {

--- a/web/src/hooks/useSpotify.ts
+++ b/web/src/hooks/useSpotify.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { apiGet, apiFetch } from '../lib/api';
 import { useSettings } from '../contexts/SettingsContext';
+import { SPOTIFY_TICKER_INTERVAL_MS, SPOTIFY_CONTROL_REFETCH_DELAY_MS } from '../lib/timing-constants';
 
 export interface SpotifyTrack {
   name: string;
@@ -37,14 +38,14 @@ export function useSpotify() {
     if (!playing || duration <= 0) return;
     tickRef.current = setInterval(() => {
       setState((prev) => {
-        const next = Math.min(prev.progressMs + 1000, duration);
+        const next = Math.min(prev.progressMs + SPOTIFY_TICKER_INTERVAL_MS, duration);
         if (next >= duration && tickRef.current) {
           clearInterval(tickRef.current);
           tickRef.current = null;
         }
         return { ...prev, progressMs: next };
       });
-    }, 1000);
+    }, SPOTIFY_TICKER_INTERVAL_MS);
   }, []);
 
   const fetchNowPlaying = useCallback(async () => {
@@ -121,7 +122,7 @@ export function useSpotify() {
     }
 
     // Re-fetch after short delay to confirm actual Spotify state
-    setTimeout(() => { void fetchNowPlaying(); }, 400);
+    setTimeout(() => { void fetchNowPlaying(); }, SPOTIFY_CONTROL_REFETCH_DELAY_MS);
   }, [fetchNowPlaying, stopTicker]);
 
   return { ...state, spotifyConnected, error, control };

--- a/web/src/hooks/useWeather.ts
+++ b/web/src/hooks/useWeather.ts
@@ -174,8 +174,8 @@ export function useWeather() {
       intervalRef.current = setInterval(async () => {
         try {
           await fetchWeather(runId);
-        } catch {
-          // silently ignore periodic refresh errors
+        } catch (err) {
+          console.warn('[weather] Periodic refresh failed:', err);
         }
       }, CACHE_EXPIRY);
     })();

--- a/web/src/lib/timing-constants.ts
+++ b/web/src/lib/timing-constants.ts
@@ -1,0 +1,29 @@
+/** Centralised timing constants — no magic numbers scattered across the codebase. */
+
+// SearchOverlay
+export const OVERLAY_OPEN_FOCUS_DELAY_MS = 30;
+export const OVERLAY_CLOSE_RESET_DELAY_MS = 300;
+export const SUGGESTIONS_DEBOUNCE_MS = 180;
+export const SEARCH_API_TIMEOUT_MS = 2000;
+
+// Quotes
+export const QUOTE_FADE_DURATION_MS = 300;
+
+// Spotify
+export const SPOTIFY_CONTROL_REFETCH_DELAY_MS = 400;
+export const SPOTIFY_TICKER_INTERVAL_MS = 1000;
+
+// Clock / Greeting
+export const CLOCK_UPDATE_INTERVAL_MS = 1000;
+export const GREETING_UPDATE_INTERVAL_MS = 60_000;
+
+// Settings UI confirmations
+export const COPY_CONFIRM_DURATION_MS = 2000;
+export const NAME_SAVE_MSG_DURATION_MS = 2000;
+export const PW_SAVE_MSG_DURATION_MS = 3000;
+
+// App loader
+export const LOADER_FADE_DURATION_MS = 600;
+
+// Calendar fetch debounce
+export const CALENDAR_FETCH_DEBOUNCE_MS = 500;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1671,9 +1671,15 @@ input[type="file"]::file-selector-button:hover {
   opacity: 0.6;
 }
 .todo-item-remove {
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
   cursor: pointer;
   opacity: 0.6;
   transition: opacity 0.3s;
+  display: flex;
+  align-items: center;
 }
 .todo-item-remove:hover {
   opacity: 1;
@@ -1924,6 +1930,9 @@ input[type="file"]::file-selector-button:hover {
   align-items: center;
   justify-content: center;
   border-radius: 10px;
+  background: none;
+  border: none;
+  color: inherit;
   cursor: pointer;
   opacity: 0.7;
   transition: all 0.25s ease;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -1980,8 +1980,24 @@ input[type="file"]::file-selector-button:hover {
   border-radius: 10px;
   color: white;
   font-size: 14px;
+  font-family: inherit;
   outline: none;
   transition: all 0.25s ease;
+}
+
+.settings-row-with-btn {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.settings-section-mt {
+  margin-top: 12px;
+}
+
+.settings-section-mt-lg {
+  margin-top: 24px;
 }
 .settings-input::placeholder {
   color: rgba(255, 255, 255, 0.35);


### PR DESCRIPTION
## Summary

- Fix `MutationObserver` never disconnecting in content script on page navigation (#151)
- Guard service worker `broadcastTabsChanged` against post-suspend execution (#150)
- Split `BackgroundContext` useEffect to prevent spurious local reloads on API key changes (#146)
- Add synchronous double-submit guards to settings form handlers (#147)
- Add `uploading`/`searching` loading states to `BackgroundSettings` and `WeatherSettings` (#142, #144)
- Replace bare `catch {}` blocks with `console.warn` in `useWeather`, `useLocation`, `useCalendar` (#139)
- Centralise all magic timeout values in `src/lib/timing-constants.ts` (#145)
- Consolidate inline styles into `.settings-input`, `.settings-row-with-btn`, `.settings-section-mt[-lg]` CSS classes (#148)
- Add focus trap (Tab interception) + `role="dialog"` + `aria-label` to `SearchOverlay` (#140)
- Convert icon-only `<span>` elements to semantic `<button>` with `aria-label` in `SettingsPanel`, `DockBar`, `TodoItem`, `LinksSettings` (#141)

## Test plan

- [ ] `npm run build` in `web/` — TypeScript and Vite build pass without errors ✅
- [ ] Load `dist/` as unpacked in Chrome, open new tab:
  - Search overlay: Tab key stays within modal, Escape closes it
  - Settings panel: close X is keyboard-accessible
  - Todo remove buttons: keyboard-accessible
- [ ] Console shows no new errors; previously-silent catch paths emit warnings on failure
- [ ] DevTools → Sources → Content Scripts: confirm `pagehide` cleanup fires on page navigation
- [ ] Upload a background image — button shows "Uploading…" feedback during processing
- [ ] Type in weather location search — "Searching…" hint appears during geocode fetch

## Issues closed
#150, #151, #146, #147, #142, #144, #139, #145, #148, #140, #141

🤖 Generated with [Claude Code](https://claude.ai/claude-code) on behalf of @Yehuda Briskman