### PR TITLE
test(web): AuthContext + SettingsContext unit tests (#137)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0-beta.30",
         "@eslint/js": "^9.39.4",
+        "@testing-library/react": "^16.3.2",
         "@types/chrome": "^0.0.287",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -23,12 +24,67 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "jsdom": "^29.0.2",
         "prettier": "^3.8.3",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.58.2",
         "vite": "^5.4.11",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -271,6 +327,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -319,6 +385,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@crxjs/vite-plugin": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@crxjs/vite-plugin/-/vite-plugin-2.3.0.tgz",
@@ -342,6 +421,146 @@
         "react-refresh": "^0.13.0",
         "rollup": "2.79.2",
         "rxjs": "7.5.7"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -879,6 +1098,24 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1389,6 +1626,63 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2041,6 +2335,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -2063,6 +2368,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2089,6 +2405,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/boolbase": {
@@ -2351,6 +2677,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -2371,6 +2711,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2389,6 +2753,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2405,6 +2776,25 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3010,6 +3400,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -3126,6 +3529,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3150,6 +3560,93 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/jsesc": {
@@ -3297,6 +3794,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3306,6 +3814,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3625,6 +4140,36 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3681,10 +4226,28 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
       "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3768,6 +4331,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -3888,6 +4464,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3980,6 +4563,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -3991,6 +4594,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4065,9 +4694,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4346,6 +4975,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -4368,6 +5020,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -4412,6 +5079,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "1.3.5",
   "type": "module",
-  "engines": { "node": ">=22" },
+  "engines": {
+    "node": ">=22"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -22,6 +24,7 @@
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0-beta.30",
     "@eslint/js": "^9.39.4",
+    "@testing-library/react": "^16.3.2",
     "@types/chrome": "^0.0.287",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -30,6 +33,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "jsdom": "^29.0.2",
     "prettier": "^3.8.3",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.58.2",

--- a/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+vi.mock('../../lib/api', () => ({
+  getAccessToken: vi.fn().mockResolvedValue(null),
+  setAccessToken: vi.fn().mockResolvedValue(undefined),
+  clearAccessToken: vi.fn().mockResolvedValue(undefined),
+  setRefreshToken: vi.fn().mockResolvedValue(undefined),
+  clearRefreshToken: vi.fn().mockResolvedValue(undefined),
+  refreshAccessToken: vi.fn().mockResolvedValue(null),
+  setLogoutCallback: vi.fn(),
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+import {
+  getAccessToken,
+  setAccessToken,
+  clearAccessToken,
+  setRefreshToken,
+  clearRefreshToken,
+  refreshAccessToken,
+  setLogoutCallback,
+  apiGet,
+  apiPost,
+} from '../../lib/api';
+import { AuthProvider, useAuth } from '../AuthContext';
+
+const mockUser = {
+  id: 'u1',
+  email: 'a@a.com',
+  name: 'Alice',
+  hasPassword: true,
+  emailVerified: true,
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+beforeEach(() => {
+  vi.mocked(getAccessToken).mockResolvedValue(null);
+  vi.mocked(refreshAccessToken).mockResolvedValue(null);
+});
+
+// ── on mount ──────────────────────────────────────────────────────────────────
+
+describe('on mount', () => {
+  it('stays unauthenticated when no stored token and refresh fails', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('loads user when a valid stored token is present', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.user).toEqual(mockUser));
+    expect(result.current.accessToken).toBe('stored-token');
+    expect(result.current.authLoading).toBe(false);
+  });
+
+  it('silently refreshes and loads user when no stored token', async () => {
+    vi.mocked(refreshAccessToken).mockResolvedValue('refreshed-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.user).toEqual(mockUser));
+  });
+
+  it('stays unauthenticated and clears token when /me fails', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockRejectedValue(new Error('network error'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+    expect(result.current.user).toBeNull();
+    expect(clearAccessToken).toHaveBeenCalled();
+  });
+
+  it('dispatches windom-auth-login event with user name on successful load', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const received: string[] = [];
+    const listener = (e: Event) => received.push((e as CustomEvent<{ name: string }>).detail.name);
+    window.addEventListener('windom-auth-login', listener);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.user).toBeTruthy());
+
+    window.removeEventListener('windom-auth-login', listener);
+    expect(received).toContain('Alice');
+  });
+});
+
+// ── login ─────────────────────────────────────────────────────────────────────
+
+describe('login', () => {
+  it('stores tokens, sets user, and clears session flags', async () => {
+    vi.mocked(apiPost).mockResolvedValue({ accessToken: 'at', refreshToken: 'rt' });
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+
+    await act(async () => { await result.current.login('a@a.com', 'pass'); });
+
+    expect(setAccessToken).toHaveBeenCalledWith('at');
+    expect(setRefreshToken).toHaveBeenCalledWith('rt');
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.sessionExpired).toBe(false);
+    expect(result.current.sessionLimitReached).toBe(false);
+  });
+
+  it('dispatches windom-auth-login event with user name', async () => {
+    vi.mocked(apiPost).mockResolvedValue({ accessToken: 'at', refreshToken: 'rt' });
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const received: string[] = [];
+    const listener = (e: Event) => received.push((e as CustomEvent<{ name: string }>).detail.name);
+    window.addEventListener('windom-auth-login', listener);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+    await act(async () => { await result.current.login('a@a.com', 'pass'); });
+
+    window.removeEventListener('windom-auth-login', listener);
+    expect(received).toContain('Alice');
+  });
+});
+
+// ── loginWithTokens ───────────────────────────────────────────────────────────
+
+describe('loginWithTokens', () => {
+  it('stores provided tokens and loads user', async () => {
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+
+    await act(async () => { await result.current.loginWithTokens('at', 'rt'); });
+
+    expect(setAccessToken).toHaveBeenCalledWith('at');
+    expect(setRefreshToken).toHaveBeenCalledWith('rt');
+    expect(result.current.user).toEqual(mockUser);
+  });
+});
+
+// ── logout ────────────────────────────────────────────────────────────────────
+
+describe('logout', () => {
+  it('calls POST /auth/logout and clears user + tokens', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+    vi.mocked(apiPost).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.user).toEqual(mockUser));
+
+    await act(async () => { await result.current.logout(); });
+
+    expect(apiPost).toHaveBeenCalledWith('/auth/logout');
+    expect(clearAccessToken).toHaveBeenCalled();
+    expect(clearRefreshToken).toHaveBeenCalled();
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('still clears state even when POST /auth/logout throws', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+    vi.mocked(apiPost).mockRejectedValue(new Error('network'));
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.user).toEqual(mockUser));
+
+    await act(async () => { await result.current.logout(); });
+
+    expect(result.current.user).toBeNull();
+    expect(clearAccessToken).toHaveBeenCalled();
+  });
+});
+
+// ── updateUser ────────────────────────────────────────────────────────────────
+
+describe('updateUser', () => {
+  it('patches specific user fields without replacing the whole object', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.user).toEqual(mockUser));
+
+    act(() => { result.current.updateUser({ name: 'Bob' }); });
+
+    expect(result.current.user?.name).toBe('Bob');
+    expect(result.current.user?.email).toBe('a@a.com'); // unchanged
+  });
+
+  it('does nothing when user is null', () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    act(() => { result.current.updateUser({ name: 'Bob' }); });
+
+    expect(result.current.user).toBeNull();
+  });
+});
+
+// ── session events ────────────────────────────────────────────────────────────
+
+describe('session events', () => {
+  it('clears user and sets sessionExpired on windom-session-expired', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+
+    act(() => { window.dispatchEvent(new CustomEvent('windom-session-expired')); });
+
+    expect(result.current.sessionExpired).toBe(true);
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('clears user and sets sessionLimitReached on windom-session-limit', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+
+    act(() => { window.dispatchEvent(new CustomEvent('windom-session-limit')); });
+
+    expect(result.current.sessionLimitReached).toBe(true);
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('clears user when the 401 logout callback registered via setLogoutCallback is fired', async () => {
+    vi.mocked(getAccessToken).mockResolvedValue('stored-token');
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.user).toEqual(mockUser));
+
+    // Retrieve the callback that AuthProvider registered with the api module
+    const [registeredCb] = vi.mocked(setLogoutCallback).mock.calls[0] as [() => void];
+
+    act(() => { registeredCb(); });
+
+    expect(result.current.user).toBeNull();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it('clears sessionExpired flag after successful login', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.authLoading).toBe(false));
+
+    act(() => { window.dispatchEvent(new CustomEvent('windom-session-expired')); });
+    expect(result.current.sessionExpired).toBe(true);
+
+    vi.mocked(apiPost).mockResolvedValue({ accessToken: 'at', refreshToken: 'rt' });
+    vi.mocked(apiGet).mockResolvedValue(mockUser);
+
+    await act(async () => { await result.current.login('a@a.com', 'pass'); });
+
+    expect(result.current.sessionExpired).toBe(false);
+  });
+});

--- a/web/src/contexts/__tests__/SettingsContext.test.tsx
+++ b/web/src/contexts/__tests__/SettingsContext.test.tsx
@@ -36,6 +36,12 @@ import { defaultSettings } from '../../types/settings';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+// @types/chrome types chrome.storage.sync.get as returning void (callback API).
+// Our stub returns a Promise, so cast to access vi mock methods without TS errors.
+function mockSyncGet(value: Record<string, unknown>) {
+  (chrome.storage.sync.get as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(value);
+}
+
 function wrapper({ children }: { children: ReactNode }) {
   return <SettingsProvider>{children}</SettingsProvider>;
 }
@@ -49,7 +55,7 @@ async function mountAndWait() {
 
 beforeEach(() => {
   // chrome.storage.sync.get(null) — called directly in the mount effect
-  vi.mocked(chrome.storage.sync.get).mockResolvedValue({});
+  mockSyncGet({});
   // Restore wrapper defaults (clearAllMocks resets call history but not implementations)
   vi.mocked(syncStorage.get).mockImplementation((_k, def) => Promise.resolve(def));
   vi.mocked(syncStorage.getMultiple).mockImplementation((keys) => Promise.resolve({ ...keys }));
@@ -102,7 +108,7 @@ describe('load on mount', () => {
 
 describe('legacy migration', () => {
   it('migrates v1 flat settings to v2 sectioned shape', async () => {
-    vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+    mockSyncGet({
       clockSize: 140,
       timeFormat: '24h',
       userName: 'Bob',
@@ -121,10 +127,7 @@ describe('legacy migration', () => {
   });
 
   it('clears sync storage and rewrites in sectioned shape during migration', async () => {
-    vi.mocked(chrome.storage.sync.get).mockResolvedValue({
-      timeFormat: '24h',
-      clockSize: 120,
-    });
+    mockSyncGet({ timeFormat: '24h', clockSize: 120 });
 
     await mountAndWait();
 
@@ -133,11 +136,7 @@ describe('legacy migration', () => {
   });
 
   it('stores the migrated focus section to localStore only', async () => {
-    vi.mocked(chrome.storage.sync.get).mockResolvedValue({
-      timeFormat: '24h',
-      mainFocus: 'Finish tests',
-      focusCompleted: false,
-    });
+    mockSyncGet({ timeFormat: '24h', mainFocus: 'Finish tests', focusCompleted: false });
 
     await mountAndWait();
 
@@ -206,8 +205,8 @@ describe('updateMultiple', () => {
 
     await act(async () => {
       await result.current.updateMultiple({
-        general: { userName: 'Eve' },
-        weather: { unit: 'C' },
+        general: { ...defaultSettings.general, userName: 'Eve' },
+        weather: { ...defaultSettings.weather, unit: 'C' as const },
       });
     });
 

--- a/web/src/contexts/__tests__/SettingsContext.test.tsx
+++ b/web/src/contexts/__tests__/SettingsContext.test.tsx
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+// chrome-storage wrappers: get/getMultiple return their defaultValue / keys argument
+// so tests see an empty store by default (same behaviour as real chrome storage with no data).
+vi.mock('../../lib/chrome-storage', () => ({
+  syncStorage: {
+    get: vi.fn().mockImplementation((_k: unknown, def: unknown) => Promise.resolve(def)),
+    getMultiple: vi.fn().mockImplementation((keys: Record<string, unknown>) => Promise.resolve({ ...keys })),
+    set: vi.fn().mockResolvedValue(true),
+    setMultiple: vi.fn().mockResolvedValue(true),
+    clear: vi.fn().mockResolvedValue(true),
+    remove: vi.fn().mockResolvedValue(true),
+    onChange: vi.fn().mockReturnValue(() => {}),
+  },
+  localStore: {
+    get: vi.fn().mockImplementation((_k: unknown, def: unknown) => Promise.resolve(def)),
+    set: vi.fn().mockResolvedValue(true),
+    clear: vi.fn().mockResolvedValue(true),
+  },
+}));
+
+// No access token → syncWithBackend returns early without touching the API.
+vi.mock('../../lib/api', () => ({
+  getAccessToken: vi.fn().mockResolvedValue(null),
+  apiGet: vi.fn(),
+  apiPut: vi.fn(),
+}));
+
+import { syncStorage, localStore } from '../../lib/chrome-storage';
+import { SettingsProvider, useSettings, useSettingsSection } from '../SettingsContext';
+import { defaultSettings } from '../../types/settings';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+/** Wait for the provider to finish its async mount (storage load). */
+async function mountAndWait() {
+  const hook = renderHook(() => useSettings(), { wrapper });
+  await waitFor(() => expect(hook.result.current.loaded).toBe(true));
+  return hook;
+}
+
+beforeEach(() => {
+  // chrome.storage.sync.get(null) — called directly in the mount effect
+  vi.mocked(chrome.storage.sync.get).mockResolvedValue({});
+  // Restore wrapper defaults (clearAllMocks resets call history but not implementations)
+  vi.mocked(syncStorage.get).mockImplementation((_k, def) => Promise.resolve(def));
+  vi.mocked(syncStorage.getMultiple).mockImplementation((keys) => Promise.resolve({ ...keys }));
+  vi.mocked(syncStorage.onChange).mockReturnValue(() => {});
+  vi.mocked(localStore.get).mockImplementation((_k, def) => Promise.resolve(def));
+});
+
+// ── load on mount ─────────────────────────────────────────────────────────────
+
+describe('load on mount', () => {
+  it('exposes defaultSettings when sync storage is empty', async () => {
+    const { result } = await mountAndWait();
+
+    expect(result.current.settings.general).toEqual(defaultSettings.general);
+    expect(result.current.settings.clock).toEqual(defaultSettings.clock);
+  });
+
+  it('loads persisted settings from sync storage', async () => {
+    const stored = {
+      ...defaultSettings,
+      general: { ...defaultSettings.general, userName: 'Alice', searchEngine: 'bing' as const },
+    };
+    vi.mocked(syncStorage.getMultiple).mockResolvedValueOnce(stored as unknown as Record<string, unknown>);
+
+    const { result } = await mountAndWait();
+
+    expect(result.current.settings.general.userName).toBe('Alice');
+    expect(result.current.settings.general.searchEngine).toBe('bing');
+  });
+
+  it('merges focus from chrome.storage.local (device-local)', async () => {
+    vi.mocked(localStore.get).mockImplementation((key, def) =>
+      Promise.resolve(key === 'windom_focus' ? { mainFocus: 'Ship it', completed: false } : def),
+    );
+
+    const { result } = await mountAndWait();
+
+    expect(result.current.settings.focus.mainFocus).toBe('Ship it');
+  });
+
+  it('sets loaded to true after async init completes', async () => {
+    const { result } = renderHook(() => useSettings(), { wrapper });
+
+    // Starts false, becomes true after storage read
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+  });
+});
+
+// ── legacy migration ──────────────────────────────────────────────────────────
+
+describe('legacy migration', () => {
+  it('migrates v1 flat settings to v2 sectioned shape', async () => {
+    vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+      clockSize: 140,
+      timeFormat: '24h',
+      userName: 'Bob',
+      backgroundSource: 'local',
+      temperatureUnit: 'C',
+      calendarDays: 14,
+    });
+
+    const { result } = await mountAndWait();
+
+    expect(result.current.settings.clock.size).toBe(140);
+    expect(result.current.settings.clock.timeFormat).toBe('24h');
+    expect(result.current.settings.general.userName).toBe('Bob');
+    expect(result.current.settings.weather.unit).toBe('C');
+    expect(result.current.settings.integrations.calendar.days).toBe(14);
+  });
+
+  it('clears sync storage and rewrites in sectioned shape during migration', async () => {
+    vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+      timeFormat: '24h',
+      clockSize: 120,
+    });
+
+    await mountAndWait();
+
+    expect(chrome.storage.sync.clear).toHaveBeenCalled();
+    expect(syncStorage.setMultiple).toHaveBeenCalled();
+  });
+
+  it('stores the migrated focus section to localStore only', async () => {
+    vi.mocked(chrome.storage.sync.get).mockResolvedValue({
+      timeFormat: '24h',
+      mainFocus: 'Finish tests',
+      focusCompleted: false,
+    });
+
+    await mountAndWait();
+
+    expect(localStore.set).toHaveBeenCalledWith(
+      'windom_focus',
+      expect.objectContaining({ mainFocus: 'Finish tests' }),
+    );
+  });
+});
+
+// ── update ────────────────────────────────────────────────────────────────────
+
+describe('update', () => {
+  it('merges a section patch into settings state', async () => {
+    const { result } = await mountAndWait();
+
+    await act(async () => {
+      await result.current.update('general', { userName: 'Charlie' });
+    });
+
+    expect(result.current.settings.general.userName).toBe('Charlie');
+    // Other fields of the section are preserved
+    expect(result.current.settings.general.searchEngine).toBe(defaultSettings.general.searchEngine);
+  });
+
+  it('writes the updated section to sync storage', async () => {
+    const { result } = await mountAndWait();
+
+    await act(async () => {
+      await result.current.update('general', { userName: 'Dana' });
+    });
+
+    expect(syncStorage.setMultiple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        general: expect.objectContaining({ userName: 'Dana' }),
+      }),
+    );
+  });
+
+  it('writes focus section to localStore only — never to sync storage', async () => {
+    const { result } = await mountAndWait();
+    vi.mocked(syncStorage.setMultiple).mockClear();
+
+    await act(async () => {
+      await result.current.update('focus', { mainFocus: 'Build something great' });
+    });
+
+    expect(result.current.settings.focus.mainFocus).toBe('Build something great');
+    expect(localStore.set).toHaveBeenCalledWith(
+      'windom_focus',
+      expect.objectContaining({ mainFocus: 'Build something great' }),
+    );
+    // setMultiple must not have been called for the focus update
+    const setMultipleCalls = vi.mocked(syncStorage.setMultiple).mock.calls;
+    for (const [arg] of setMultipleCalls) {
+      expect(arg).not.toHaveProperty('focus');
+    }
+  });
+});
+
+// ── updateMultiple ────────────────────────────────────────────────────────────
+
+describe('updateMultiple', () => {
+  it('applies patches to multiple sections in one call', async () => {
+    const { result } = await mountAndWait();
+
+    await act(async () => {
+      await result.current.updateMultiple({
+        general: { userName: 'Eve' },
+        weather: { unit: 'C' },
+      });
+    });
+
+    expect(result.current.settings.general.userName).toBe('Eve');
+    expect(result.current.settings.weather.unit).toBe('C');
+  });
+});
+
+// ── reset ─────────────────────────────────────────────────────────────────────
+
+describe('reset', () => {
+  it('restores defaultSettings and clears sync storage', async () => {
+    const { result } = await mountAndWait();
+
+    // First, change something
+    await act(async () => {
+      await result.current.update('general', { userName: 'Temp' });
+    });
+    expect(result.current.settings.general.userName).toBe('Temp');
+
+    await act(async () => { await result.current.reset(); });
+
+    expect(result.current.settings.general.userName).toBe(defaultSettings.general.userName);
+    expect(result.current.settings.clock).toEqual(defaultSettings.clock);
+    expect(syncStorage.clear).toHaveBeenCalled();
+  });
+
+  it('rewrites defaultSettings to sync storage after reset', async () => {
+    const { result } = await mountAndWait();
+    vi.mocked(syncStorage.setMultiple).mockClear();
+
+    await act(async () => { await result.current.reset(); });
+
+    expect(syncStorage.setMultiple).toHaveBeenCalledWith(
+      expect.objectContaining({ general: defaultSettings.general }),
+    );
+  });
+});
+
+// ── cross-tab sync (onChanged) ────────────────────────────────────────────────
+
+describe('cross-tab sync', () => {
+  it('applies incoming section changes from another tab', async () => {
+    let capturedCb: ((changes: Record<string, { newValue: unknown }>) => void) | null = null;
+    vi.mocked(syncStorage.onChange).mockImplementation((cb) => {
+      capturedCb = cb as (changes: Record<string, { newValue: unknown }>) => void;
+      return () => {};
+    });
+
+    const { result } = await mountAndWait();
+
+    act(() => {
+      capturedCb!({
+        general: { newValue: { ...defaultSettings.general, userName: 'Remote' } },
+      });
+    });
+
+    await waitFor(() => expect(result.current.settings.general.userName).toBe('Remote'));
+  });
+
+  it('ignores changes whose remote timestamp is behind the local timestamp', async () => {
+    let capturedCb: ((changes: Record<string, { newValue: unknown; oldValue?: unknown }>) => void) | null = null;
+    vi.mocked(syncStorage.onChange).mockImplementation((cb) => {
+      capturedCb = cb as typeof capturedCb;
+      return () => {};
+    });
+
+    const { result } = await mountAndWait();
+
+    // Make a local update (sets a local timestamp for 'general')
+    await act(async () => {
+      await result.current.update('general', { userName: 'Local' });
+    });
+
+    const localTs = Date.now();
+
+    // Remote change with an older timestamp
+    act(() => {
+      capturedCb!({
+        windom_key_timestamps: { newValue: { general: localTs - 1000 } },
+        general: { newValue: { ...defaultSettings.general, userName: 'Stale' } },
+      });
+    });
+
+    // Local value should win
+    expect(result.current.settings.general.userName).toBe('Local');
+  });
+});
+
+// ── get helper ────────────────────────────────────────────────────────────────
+
+describe('get', () => {
+  it('returns the requested section', async () => {
+    const { result } = await mountAndWait();
+
+    expect(result.current.get('general')).toEqual(result.current.settings.general);
+    expect(result.current.get('clock')).toEqual(result.current.settings.clock);
+  });
+});
+
+// ── useSettingsSection ────────────────────────────────────────────────────────
+
+describe('useSettingsSection', () => {
+  it('returns the current value of the subscribed section', async () => {
+    const { result } = renderHook(
+      () => ({ section: useSettingsSection('general'), ctx: useSettings() }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.ctx.loaded).toBe(true));
+    expect(result.current.section).toEqual(defaultSettings.general);
+  });
+
+  it('reflects updates to the subscribed section', async () => {
+    const { result } = renderHook(
+      () => ({ section: useSettingsSection('general'), ctx: useSettings() }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.ctx.loaded).toBe(true));
+
+    await act(async () => {
+      await result.current.ctx.update('general', { userName: 'Felix' });
+    });
+
+    expect(result.current.section.userName).toBe('Felix');
+  });
+});

--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,0 +1,44 @@
+import { vi, beforeEach, afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => cleanup());
+
+// ── Chrome API global stub ─────────────────────────────────────────────────
+// Provides chrome.storage.sync / local / onChanged used directly in
+// SettingsContext (chrome.storage.sync.get(null)) and indirectly through
+// the chrome-storage.ts wrappers.
+
+const chromeMock = {
+  storage: {
+    sync: {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+      remove: vi.fn().mockResolvedValue(undefined),
+    },
+    local: {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue(undefined),
+      clear: vi.fn().mockResolvedValue(undefined),
+    },
+    onChanged: {
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    },
+  },
+};
+
+// @ts-expect-error - chrome is not defined in jsdom
+globalThis.chrome = chromeMock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Restore default implementations after clearAllMocks resets call history
+  chromeMock.storage.sync.get.mockResolvedValue({});
+  chromeMock.storage.sync.set.mockResolvedValue(undefined);
+  chromeMock.storage.sync.clear.mockResolvedValue(undefined);
+  chromeMock.storage.sync.remove.mockResolvedValue(undefined);
+  chromeMock.storage.local.get.mockResolvedValue({});
+  chromeMock.storage.local.set.mockResolvedValue(undefined);
+  chromeMock.storage.local.clear.mockResolvedValue(undefined);
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  define: {
+    __BACKEND_URL__: JSON.stringify('http://localhost:8080'),
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test-setup.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `@testing-library/react` + `jsdom` as dev dependencies
- Creates `web/vitest.config.ts` — jsdom environment, shared setup file
- Creates `web/src/test-setup.ts` — chrome API global stub + RTL cleanup after each test
- Creates `web/src/contexts/__tests__/AuthContext.test.tsx` — 16 tests
- Creates `web/src/contexts/__tests__/SettingsContext.test.tsx` — 18 tests

**AuthContext** tests cover: silent refresh on mount, user load via `/me`, `login()` / `loginWithTokens()` token storage, `logout()` (including best-effort failure), `updateUser()` patching, `windom-session-expired` / `windom-session-limit` window events, and the 401 logout callback fired by `setLogoutCallback`.

**SettingsContext** tests cover: defaults when storage is empty, persisted settings load, v1→v2 flat migration (clears sync, rewrites sectioned, moves focus to local), `update()` merging with sync-storage write, focus-only writes to `localStore` exclusively, `updateMultiple()`, `reset()`, cross-tab `onChanged` sync with timestamp-based conflict resolution, and `useSettingsSection`.

## Test plan

- [x] `npx vitest run` → 38 tests pass across 3 test files (including the existing `migrateSettings.test.ts`)
- [x] No new ESLint/TypeScript errors introduced (test-only files)

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)