### PR TITLE
security: narrow google host permission in manifest

### DIFF
--- a/web/manifest.json
+++ b/web/manifest.json
@@ -17,7 +17,7 @@
     "https://nominatim.openstreetmap.org/*",
     "https://ipapi.co/*",
     "https://api.quotable.io/*",
-    "https://www.google.com/*",
+    "https://www.google.com/s2/favicons*",
     "https://duckduckgo.com/*",
     "https://api.windom.app/*"
   ],


### PR DESCRIPTION
## What
- Replace `https://www.google.com/*` with `https://www.google.com/s2/favicons*` in `manifest.json`

## Why
The extension only fetches one Google URL directly — the favicon API at `/s2/favicons`. Google OAuth is handled entirely by `chrome.identity.launchWebAuthFlow` (no host_permission needed), and Google Search is opened as a new tab (also no host_permission needed). The wildcard `/*` granted unnecessary access to all Google properties, which is flagged by Chrome Web Store reviewers and reduces user trust.

## How
Changed the single `host_permissions` entry from `https://www.google.com/*` to `https://www.google.com/s2/favicons*`. No code changes required — the favicon URL in `src/utils/url.ts` already targets exactly that path.

## Test plan
- [ ] Extension builds without errors (`npm run build` in `web/`)
- [ ] Favicon loads correctly for links in the dock and quick links sections
- [ ] Google search still works (opens a new tab)
- [ ] Google Sign-In still works via chrome.identity flow

Closes #120

Generated by [Claude-Bot] of [@Yehuda Briskman]