### PR TITLE
feat: sync fly secrets from github actions on deploy

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -74,6 +74,31 @@ jobs:
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
+      - name: Sync secrets to Fly.io
+        working-directory: backend
+        run: |
+          flyctl secrets set \
+            DATABASE_URL="${{ secrets.DATABASE_URL }}" \
+            JWT_ACCESS_SECRET="${{ secrets.JWT_ACCESS_SECRET }}" \
+            REFRESH_TOKEN_SECRET="${{ secrets.REFRESH_TOKEN_SECRET }}" \
+            TOKEN_ENC_KEY_BASE64="${{ secrets.TOKEN_ENC_KEY_BASE64 }}" \
+            GOOGLE_CLIENT_ID="${{ secrets.GOOGLE_CLIENT_ID }}" \
+            GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
+            GOOGLE_REDIRECT_URI="${{ secrets.GOOGLE_REDIRECT_URI }}" \
+            SPOTIFY_CLIENT_ID="${{ secrets.SPOTIFY_CLIENT_ID }}" \
+            SPOTIFY_CLIENT_SECRET="${{ secrets.SPOTIFY_CLIENT_SECRET }}" \
+            SPOTIFY_REDIRECT_URI="${{ secrets.SPOTIFY_REDIRECT_URI }}" \
+            CORS_ALLOWED_ORIGINS="${{ secrets.CORS_ALLOWED_ORIGINS }}" \
+            SMTP_HOST="${{ secrets.SMTP_HOST }}" \
+            SMTP_PORT="${{ secrets.SMTP_PORT }}" \
+            SMTP_USER="${{ secrets.SMTP_USER }}" \
+            SMTP_PASS="${{ secrets.SMTP_PASS }}" \
+            SMTP_FROM="${{ secrets.SMTP_FROM }}" \
+            CHROME_EXTENSION_ID="${{ secrets.CHROME_EXTENSION_ID }}" \
+            --stage
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
       - name: Deploy to Fly.io
         working-directory: backend
         run: flyctl deploy --remote-only


### PR DESCRIPTION
## What
- Add a `flyctl secrets set` step before each deploy to push all env secrets from GitHub Actions to Fly.io
- Secrets are staged (`--stage`) so no premature restart occurs before the new build is ready

## Why
Without this step, secrets set via `fly secrets set` on a local machine can silently drift from the values in GitHub Actions secrets. A deploy would then land with stale secrets — wrong DB URL, outdated OAuth credentials, or a revoked SMTP password — causing runtime failures that are hard to diagnose from logs alone.

## How
The new step runs `flyctl secrets set KEY="${{ secrets.KEY }}" ... --stage` for all required env vars. Using `--stage` means Fly.io holds the new values but does not restart any machines. The subsequent `flyctl deploy` picks up the staged secrets atomically with the new image, so there is never a window where the app runs with mismatched secrets and code.

## Test plan
- [ ] Trigger a deploy by pushing a `v*` tag
- [ ] Confirm the secrets sync step passes in CI logs
- [ ] Confirm `flyctl secrets list` on the app shows updated `updated_at` timestamps
- [ ] Confirm the new deploy starts successfully with the correct config

Closes #52

Generated by [Claude-Bot] of [@Yehuda Briskman]