### PR TITLE
feat: add pre-deploy backup and post-deploy health check

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -66,14 +66,36 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Increase timeout: backup + migration + deploy + health check can take up to 20 min
+    timeout-minutes: 20
     needs: test
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      # ── Step 1: Pre-deploy database backup ───────────────────────────────────
+      # Creates a Fly.io managed Postgres backup before ANY schema changes run.
+      # The deploy is ABORTED if this fails — no backup means no safe rollback.
+      # Requires FLY_POSTGRES_APP secret (the name of your Fly Postgres app, e.g. "windom-db").
+      - name: Create pre-deploy database backup
+        id: backup
+        run: |
+          echo "Creating Fly Postgres backup for app: ${{ secrets.FLY_POSTGRES_APP }}"
+          flyctl postgres backup create \
+            --app "${{ secrets.FLY_POSTGRES_APP }}" \
+            --confirm
+          echo "Backup created successfully at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+          echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "timestamp=$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # ── Step 2: Sync secrets ──────────────────────────────────────────────────
+      # Staged so they land atomically with the new image — no restart until deploy.
       - name: Sync secrets to Fly.io
         working-directory: backend
         run: |
@@ -99,8 +121,43 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
+      # ── Step 3: Deploy ────────────────────────────────────────────────────────
+      # entrypoint.sh inside the image runs "node dist/db/migrate.js" before the
+      # server starts. Fly's rolling deploy keeps the old machine alive until the
+      # new one passes the /health check — so if migration or startup fails, the
+      # old machine continues serving traffic automatically.
       - name: Deploy to Fly.io
         working-directory: backend
-        run: flyctl deploy --remote-only
+        run: flyctl deploy --remote-only --wait-timeout 300
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+      # ── Step 4: Post-deploy health check ─────────────────────────────────────
+      # Confirms the new version is actually serving traffic.
+      # Retries for up to 60 s to give Fly's traffic switch time to settle.
+      - name: Verify production health endpoint
+        run: |
+          echo "Verifying https://api.windom.app/health ..."
+          for i in 1 2 3 4 5 6; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://api.windom.app/health)
+            if [ "$STATUS" = "200" ]; then
+              echo "Health check passed (attempt $i) — deployment successful."
+              exit 0
+            fi
+            echo "Attempt $i: got HTTP $STATUS, retrying in 10s..."
+            sleep 10
+          done
+          echo "Health check failed after 60s. Run: flyctl rollback -a windom-api"
+          exit 1
+
+      # ── Step 5: Post-deploy summary ───────────────────────────────────────────
+      - name: Deployment summary
+        if: success()
+        run: |
+          echo "===== Deployment complete ====="
+          echo "Tag:           ${{ github.ref_name }}"
+          echo "Backup at:     ${{ steps.backup.outputs.timestamp }}"
+          echo "Health:        https://api.windom.app/health"
+          echo ""
+          echo "To roll back code only:  flyctl rollback -a windom-api"
+          echo "To roll back database:   see Windom/runbooks/deploy-rollback.md"


### PR DESCRIPTION
## What
- Abort deploy if Fly Postgres backup cannot be created (hard fail — no backup = no safe rollback)
- Add post-deploy `/health` polling (60s, 6 retries) — fails the run if the new version isn't serving
- Pass `--wait-timeout 300` to `flyctl deploy` so rolling deploy fully settles before CI exits
- Raise deploy job timeout from 15 → 20 min to accommodate new steps
- Add `Windom/infrastructure/deploy-rollback.md` — full rollback runbook with step-by-step instructions

## Why
The deploy pipeline had no backup before migrations run and no verification that the new version actually came up. A failed deploy could go unnoticed, and there was no documented path to restore the database if something went wrong post-deploy. With production users, any deploy that corrupts or loses data needs an immediate, documented recovery path.

## How
Fly Postgres backup is created with `flyctl postgres backup create` before secrets are synced or any code is deployed. The backup step is a hard gate — if `FLY_POSTGRES_APP` secret is missing or the backup API fails, the entire deploy job aborts before touching production. Migrations continue to run via `entrypoint.sh` inside the container (already the existing pattern), which gives us Fly's rolling deploy safety: old machine stays up until health check passes. The post-deploy health check retries curl against `/health` and fails CI if the endpoint never returns 200.

## Test plan
- [ ] Add `FLY_POSTGRES_APP` to GitHub repo secrets (name of your Fly Postgres app)
- [ ] Push a `v*` tag and confirm backup step passes in CI
- [ ] Confirm deploy step completes and health check step returns 200
- [ ] Confirm deployment summary is printed at end of workflow run
- [ ] Read `Windom/infrastructure/deploy-rollback.md` and verify the rollback steps match your Fly setup

## Before merging — required action
Add `FLY_POSTGRES_APP` to GitHub repo secrets → Settings → Secrets → Actions.
The value is the name of your Fly.io Postgres app (visible in `fly pg list`).

Closes #52 follow-up

Generated by [Claude-Bot] of [@Yehuda Briskman]