### PR TITLE
feat: phase 7.5 UX enhancements — weather, apps hub, templates

### DIFF
--- a/web/public/templates/dashboard.svg
+++ b/web/public/templates/dashboard.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#071a0f"/>
+      <stop offset="100%" stop-color="#0d2818"/>
+    </linearGradient>
+  </defs>
+  <rect width="300" height="200" fill="url(#g)" rx="12"/>
+  <ellipse cx="150" cy="90" rx="120" ry="70" fill="#4ade80" opacity="0.04"/>
+  <!-- Clock -->
+  <text x="150" y="48" font-family="system-ui,sans-serif" font-size="26" font-weight="400" fill="rgba(255,255,255,0.9)" text-anchor="middle">12:00</text>
+  <text x="150" y="62" font-family="system-ui,sans-serif" font-size="8" fill="rgba(74,222,128,0.5)" text-anchor="middle" letter-spacing="1">THU APR 24</text>
+  <!-- Weather -->
+  <rect x="124" y="70" width="52" height="14" rx="7" fill="rgba(74,222,128,0.12)" stroke="rgba(74,222,128,0.25)" stroke-width="0.6"/>
+  <text x="150" y="80" font-family="system-ui,sans-serif" font-size="8" fill="rgba(74,222,128,0.85)" text-anchor="middle">☀ 72°F</text>
+  <!-- Links row -->
+  <rect x="42" y="95" width="28" height="15" rx="5" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="78" y="95" width="28" height="15" rx="5" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="114" y="95" width="28" height="15" rx="5" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="150" y="95" width="28" height="15" rx="5" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="186" y="95" width="28" height="15" rx="5" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="222" y="95" width="28" height="15" rx="5" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <!-- Focus bar -->
+  <rect x="50" y="122" width="200" height="16" rx="7" fill="rgba(255,255,255,0.05)" stroke="rgba(74,222,128,0.2)" stroke-width="0.7"/>
+  <text x="150" y="133" font-family="system-ui,sans-serif" font-size="7.5" fill="rgba(255,255,255,0.2)" text-anchor="middle">What's your main focus today?</text>
+  <!-- Quote strip -->
+  <rect x="50" y="150" width="200" height="22" rx="7" fill="rgba(255,255,255,0.04)" stroke="rgba(74,222,128,0.12)" stroke-width="0.6"/>
+  <rect x="62" y="158" width="130" height="5" rx="2.5" fill="rgba(255,255,255,0.15)"/>
+  <rect x="62" y="167" width="90" height="4" rx="2" fill="rgba(74,222,128,0.2)"/>
+  <text x="150" y="190" font-family="system-ui,sans-serif" font-size="9" fill="rgba(74,222,128,0.4)" text-anchor="middle" letter-spacing="2">DASHBOARD</text>
+</svg>

--- a/web/public/templates/focus-only.svg
+++ b/web/public/templates/focus-only.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+  <defs>
+    <linearGradient id="g" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1a0510"/>
+      <stop offset="100%" stop-color="#200813"/>
+    </linearGradient>
+  </defs>
+  <rect width="300" height="200" fill="url(#g)" rx="12"/>
+  <ellipse cx="150" cy="120" rx="90" ry="55" fill="#fb7185" opacity="0.07"/>
+  <!-- Small time -->
+  <text x="150" y="50" font-family="system-ui,sans-serif" font-size="18" font-weight="200" fill="rgba(255,255,255,0.4)" text-anchor="middle">12:00</text>
+  <!-- Focus prompt — large and prominent -->
+  <rect x="36" y="68" width="228" height="68" rx="14" fill="rgba(251,113,133,0.07)" stroke="rgba(251,113,133,0.2)" stroke-width="1"/>
+  <text x="150" y="92" font-family="system-ui,sans-serif" font-size="9" fill="rgba(251,113,133,0.55)" text-anchor="middle" letter-spacing="2">TODAY'S FOCUS</text>
+  <!-- Input placeholder lines -->
+  <rect x="60" y="102" width="130" height="8" rx="4" fill="rgba(255,255,255,0.18)"/>
+  <rect x="60" y="116" width="80" height="6" rx="3" fill="rgba(255,255,255,0.1)"/>
+  <!-- Cursor blink -->
+  <rect x="148" y="102" width="2" height="8" rx="1" fill="rgba(251,113,133,0.7)"/>
+  <text x="150" y="168" font-family="system-ui,sans-serif" font-size="9" fill="rgba(251,113,133,0.35)" text-anchor="middle" letter-spacing="2">DEEP FOCUS</text>
+</svg>

--- a/web/public/templates/inspiration.svg
+++ b/web/public/templates/inspiration.svg
@@ -1,24 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
   <defs>
-    <linearGradient id="bg-ins" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#1a0a2e"/>
-      <stop offset="100%" style="stop-color:#16213e"/>
+    <linearGradient id="g" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#1c1008"/>
+      <stop offset="100%" stop-color="#2d1f00"/>
     </linearGradient>
   </defs>
-  <!-- Background -->
-  <rect width="300" height="200" fill="url(#bg-ins)" rx="12"/>
-  <!-- Clock small -->
-  <text x="150" y="48" font-family="system-ui,sans-serif" font-size="22" font-weight="200" fill="rgba(255,255,255,0.7)" text-anchor="middle">12:00</text>
-  <!-- Quote glass panel -->
-  <rect x="30" y="65" width="240" height="80" rx="12" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="1"/>
-  <!-- Opening quote mark -->
-  <text x="46" y="95" font-family="Georgia,serif" font-size="28" fill="rgba(255,255,255,0.15)">"</text>
-  <!-- Quote text lines -->
-  <rect x="55" y="88" width="180" height="7" rx="3" fill="rgba(255,255,255,0.2)"/>
-  <rect x="55" y="102" width="160" height="7" rx="3" fill="rgba(255,255,255,0.2)"/>
-  <rect x="55" y="116" width="100" height="7" rx="3" fill="rgba(255,255,255,0.15)"/>
-  <!-- Author line -->
-  <rect x="160" y="128" width="80" height="5" rx="2" fill="rgba(255,255,255,0.1)"/>
-  <!-- Label -->
-  <text x="150" y="175" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.3)" text-anchor="middle">Inspiration</text>
+  <rect width="300" height="200" fill="url(#g)" rx="12"/>
+  <ellipse cx="150" cy="110" rx="100" ry="60" fill="#f59e0b" opacity="0.06"/>
+  <!-- Small clock -->
+  <text x="150" y="38" font-family="system-ui,sans-serif" font-size="20" font-weight="200" fill="rgba(255,255,255,0.55)" text-anchor="middle">12:00</text>
+  <!-- Quote panel -->
+  <rect x="28" y="52" width="244" height="96" rx="14" fill="rgba(255,255,255,0.04)" stroke="rgba(245,158,11,0.2)" stroke-width="1"/>
+  <!-- Opening quote -->
+  <text x="44" y="84" font-family="Georgia,serif" font-size="32" fill="rgba(245,158,11,0.35)">"</text>
+  <!-- Quote lines -->
+  <rect x="54" y="75" width="174" height="7" rx="3.5" fill="rgba(255,255,255,0.22)"/>
+  <rect x="54" y="89" width="152" height="7" rx="3.5" fill="rgba(255,255,255,0.22)"/>
+  <rect x="54" y="103" width="110" height="7" rx="3.5" fill="rgba(255,255,255,0.18)"/>
+  <!-- Author -->
+  <rect x="168" y="118" width="88" height="5" rx="2.5" fill="rgba(245,158,11,0.3)"/>
+  <!-- Closing quote -->
+  <text x="247" y="135" font-family="Georgia,serif" font-size="20" fill="rgba(245,158,11,0.2)">"</text>
+  <text x="150" y="168" font-family="system-ui,sans-serif" font-size="9" fill="rgba(245,158,11,0.4)" text-anchor="middle" letter-spacing="2">INSPIRATION</text>
 </svg>

--- a/web/public/templates/inspiration.svg
+++ b/web/public/templates/inspiration.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+  <defs>
+    <linearGradient id="bg-ins" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#1a0a2e"/>
+      <stop offset="100%" style="stop-color:#16213e"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="300" height="200" fill="url(#bg-ins)" rx="12"/>
+  <!-- Clock small -->
+  <text x="150" y="48" font-family="system-ui,sans-serif" font-size="22" font-weight="200" fill="rgba(255,255,255,0.7)" text-anchor="middle">12:00</text>
+  <!-- Quote glass panel -->
+  <rect x="30" y="65" width="240" height="80" rx="12" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="1"/>
+  <!-- Opening quote mark -->
+  <text x="46" y="95" font-family="Georgia,serif" font-size="28" fill="rgba(255,255,255,0.15)">"</text>
+  <!-- Quote text lines -->
+  <rect x="55" y="88" width="180" height="7" rx="3" fill="rgba(255,255,255,0.2)"/>
+  <rect x="55" y="102" width="160" height="7" rx="3" fill="rgba(255,255,255,0.2)"/>
+  <rect x="55" y="116" width="100" height="7" rx="3" fill="rgba(255,255,255,0.15)"/>
+  <!-- Author line -->
+  <rect x="160" y="128" width="80" height="5" rx="2" fill="rgba(255,255,255,0.1)"/>
+  <!-- Label -->
+  <text x="150" y="175" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.3)" text-anchor="middle">Inspiration</text>
+</svg>

--- a/web/public/templates/minimal.svg
+++ b/web/public/templates/minimal.svg
@@ -1,16 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
   <defs>
-    <linearGradient id="bg-min" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0c1a"/>
-      <stop offset="100%" style="stop-color:#1a1228"/>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="100%" stop-color="#302b63"/>
     </linearGradient>
   </defs>
-  <!-- Background -->
-  <rect width="300" height="200" fill="url(#bg-min)" rx="12"/>
-  <!-- Subtle grid overlay -->
+  <rect width="300" height="200" fill="url(#g)" rx="12"/>
+  <!-- Subtle noise texture -->
   <rect width="300" height="200" fill="rgba(255,255,255,0.02)" rx="12"/>
-  <!-- Clock — large, centered, minimal -->
-  <text x="150" y="112" font-family="system-ui,sans-serif" font-size="48" font-weight="200" fill="rgba(255,255,255,0.9)" text-anchor="middle" dominant-baseline="middle">12:00</text>
-  <!-- Label -->
-  <text x="150" y="175" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.3)" text-anchor="middle">Minimal</text>
+  <!-- Accent glow -->
+  <ellipse cx="150" cy="100" rx="60" ry="40" fill="#6366f1" opacity="0.08"/>
+  <!-- Large minimal clock -->
+  <text x="150" y="118" font-family="system-ui,sans-serif" font-size="52" font-weight="200" fill="rgba(255,255,255,0.92)" text-anchor="middle" dominant-baseline="middle" letter-spacing="-2">12:00</text>
+  <!-- No widgets indicator -->
+  <text x="150" y="158" font-family="system-ui,sans-serif" font-size="10" fill="rgba(255,255,255,0.2)" text-anchor="middle" letter-spacing="3">MINIMAL</text>
 </svg>

--- a/web/public/templates/minimal.svg
+++ b/web/public/templates/minimal.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+  <defs>
+    <linearGradient id="bg-min" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0f0c1a"/>
+      <stop offset="100%" style="stop-color:#1a1228"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="300" height="200" fill="url(#bg-min)" rx="12"/>
+  <!-- Subtle grid overlay -->
+  <rect width="300" height="200" fill="rgba(255,255,255,0.02)" rx="12"/>
+  <!-- Clock — large, centered, minimal -->
+  <text x="150" y="112" font-family="system-ui,sans-serif" font-size="48" font-weight="200" fill="rgba(255,255,255,0.9)" text-anchor="middle" dominant-baseline="middle">12:00</text>
+  <!-- Label -->
+  <text x="150" y="175" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.3)" text-anchor="middle">Minimal</text>
+</svg>

--- a/web/public/templates/night.svg
+++ b/web/public/templates/night.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#05020f"/>
+      <stop offset="100%" stop-color="#120a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="300" height="200" fill="url(#g)" rx="12"/>
+  <!-- Stars -->
+  <circle cx="48" cy="28" r="1.2" fill="rgba(167,139,250,0.6)"/>
+  <circle cx="92" cy="18" r="0.8" fill="rgba(255,255,255,0.4)"/>
+  <circle cx="180" cy="22" r="1" fill="rgba(167,139,250,0.5)"/>
+  <circle cx="240" cy="14" r="1.4" fill="rgba(255,255,255,0.35)"/>
+  <circle cx="265" cy="35" r="0.9" fill="rgba(167,139,250,0.45)"/>
+  <circle cx="28" cy="55" r="0.7" fill="rgba(255,255,255,0.3)"/>
+  <circle cx="272" cy="70" r="1.1" fill="rgba(167,139,250,0.4)"/>
+  <!-- Accent glow -->
+  <ellipse cx="150" cy="105" rx="70" ry="45" fill="#a78bfa" opacity="0.07"/>
+  <!-- Outline clock: stroke-only text -->
+  <text x="150" y="118" font-family="system-ui,sans-serif" font-size="54" font-weight="100" fill="none" stroke="#a78bfa" stroke-width="1.2" text-anchor="middle" dominant-baseline="middle" letter-spacing="-2" opacity="0.85">12:00</text>
+  <!-- Focus bar -->
+  <rect x="80" y="148" width="140" height="16" rx="7" fill="rgba(167,139,250,0.08)" stroke="rgba(167,139,250,0.25)" stroke-width="0.7"/>
+  <text x="150" y="159" font-family="system-ui,sans-serif" font-size="7.5" fill="rgba(167,139,250,0.4)" text-anchor="middle">Today's intention…</text>
+  <text x="150" y="184" font-family="system-ui,sans-serif" font-size="9" fill="rgba(167,139,250,0.35)" text-anchor="middle" letter-spacing="2">NIGHT OWL</text>
+</svg>

--- a/web/public/templates/productivity.svg
+++ b/web/public/templates/productivity.svg
@@ -1,23 +1,25 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200">
   <defs>
-    <linearGradient id="bg-prod" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0d1117"/>
-      <stop offset="100%" style="stop-color:#161b22"/>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d1b2a"/>
+      <stop offset="100%" stop-color="#1b2838"/>
     </linearGradient>
   </defs>
-  <!-- Background -->
-  <rect width="300" height="200" fill="url(#bg-prod)" rx="12"/>
+  <rect width="300" height="200" fill="url(#g)" rx="12"/>
+  <ellipse cx="150" cy="60" rx="80" ry="30" fill="#22d3ee" opacity="0.06"/>
   <!-- Clock -->
-  <text x="150" y="72" font-family="system-ui,sans-serif" font-size="34" font-weight="200" fill="rgba(255,255,255,0.9)" text-anchor="middle">12:00</text>
-  <text x="150" y="92" font-family="system-ui,sans-serif" font-size="10" fill="rgba(255,255,255,0.4)" text-anchor="middle">Thursday, April 24</text>
+  <text x="150" y="55" font-family="system-ui,sans-serif" font-size="30" font-weight="200" fill="rgba(255,255,255,0.9)" text-anchor="middle">12:00</text>
+  <text x="150" y="72" font-family="system-ui,sans-serif" font-size="9" fill="rgba(255,255,255,0.35)" text-anchor="middle" letter-spacing="1">THURSDAY, APRIL 24</text>
+  <!-- Weather pill -->
+  <rect x="127" y="82" width="46" height="16" rx="8" fill="rgba(34,211,238,0.15)" stroke="rgba(34,211,238,0.3)" stroke-width="0.5"/>
+  <text x="150" y="93" font-family="system-ui,sans-serif" font-size="8.5" fill="rgba(34,211,238,0.9)" text-anchor="middle">72° F</text>
   <!-- Quick links row -->
-  <rect x="60" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
-  <rect x="104" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
-  <rect x="148" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
-  <rect x="192" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
+  <rect x="50" y="111" width="34" height="18" rx="6" fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="92" y="111" width="34" height="18" rx="6" fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="134" y="111" width="34" height="18" rx="6" fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
+  <rect x="176" y="111" width="34" height="18" rx="6" fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.1)" stroke-width="0.5"/>
   <!-- Focus bar -->
-  <rect x="75" y="140" width="150" height="22" rx="8" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="1"/>
-  <text x="150" y="155" font-family="system-ui,sans-serif" font-size="9" fill="rgba(255,255,255,0.35)" text-anchor="middle">What's your main focus today?</text>
-  <!-- Label -->
-  <text x="150" y="185" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.3)" text-anchor="middle">Productivity</text>
+  <rect x="60" y="143" width="180" height="20" rx="8" fill="rgba(255,255,255,0.05)" stroke="rgba(34,211,238,0.2)" stroke-width="0.8"/>
+  <text x="150" y="157" font-family="system-ui,sans-serif" font-size="8" fill="rgba(255,255,255,0.25)" text-anchor="middle">What's your main focus today?</text>
+  <text x="150" y="182" font-family="system-ui,sans-serif" font-size="9" fill="rgba(34,211,238,0.4)" text-anchor="middle" letter-spacing="2">PRODUCTIVITY</text>
 </svg>

--- a/web/public/templates/productivity.svg
+++ b/web/public/templates/productivity.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 200" width="300" height="200">
+  <defs>
+    <linearGradient id="bg-prod" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d1117"/>
+      <stop offset="100%" style="stop-color:#161b22"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect width="300" height="200" fill="url(#bg-prod)" rx="12"/>
+  <!-- Clock -->
+  <text x="150" y="72" font-family="system-ui,sans-serif" font-size="34" font-weight="200" fill="rgba(255,255,255,0.9)" text-anchor="middle">12:00</text>
+  <text x="150" y="92" font-family="system-ui,sans-serif" font-size="10" fill="rgba(255,255,255,0.4)" text-anchor="middle">Thursday, April 24</text>
+  <!-- Quick links row -->
+  <rect x="60" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
+  <rect x="104" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
+  <rect x="148" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
+  <rect x="192" y="108" width="36" height="20" rx="6" fill="rgba(255,255,255,0.08)"/>
+  <!-- Focus bar -->
+  <rect x="75" y="140" width="150" height="22" rx="8" fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.1)" stroke-width="1"/>
+  <text x="150" y="155" font-family="system-ui,sans-serif" font-size="9" fill="rgba(255,255,255,0.35)" text-anchor="middle">What's your main focus today?</text>
+  <!-- Label -->
+  <text x="150" y="185" font-family="system-ui,sans-serif" font-size="11" fill="rgba(255,255,255,0.3)" text-anchor="middle">Productivity</text>
+</svg>

--- a/web/src/components/background/PhotographerCredit.tsx
+++ b/web/src/components/background/PhotographerCredit.tsx
@@ -15,7 +15,7 @@ export function PhotographerCredit() {
   const isLiked = currentPhoto?.liked ?? false;
 
   return (
-    <div className="photographer-credit glass-credit text-shadow-credit">
+    <div className="photographer-credit text-shadow-credit">
       <button
         className={`photo-credit-like-btn ${isLiked ? "liked" : ""}`}
         onClick={() => currentPhotoId && toggleLike(currentPhotoId)}

--- a/web/src/components/settings/SettingsNav.tsx
+++ b/web/src/components/settings/SettingsNav.tsx
@@ -1,4 +1,4 @@
-const TABS = ['general', 'clock', 'background', 'weather', 'quotes', 'links', 'apps', 'account'] as const;
+const TABS = ['general', 'clock', 'background', 'weather', 'quotes', 'links', 'apps', 'templates', 'account'] as const;
 export type SettingsTab = typeof TABS[number];
 
 const LABELS: Record<SettingsTab, string> = {
@@ -9,6 +9,7 @@ const LABELS: Record<SettingsTab, string> = {
   quotes: 'Quotes',
   links: 'Links',
   apps: 'Apps',
+  templates: 'Templates',
   account: 'Account',
 };
 

--- a/web/src/components/settings/SettingsNav.tsx
+++ b/web/src/components/settings/SettingsNav.tsx
@@ -1,6 +1,4 @@
-import { useAuth } from '../../contexts/AuthContext';
-
-const TABS = ['general', 'clock', 'background', 'weather', 'quotes', 'links', 'calendar', 'spotify', 'account'] as const;
+const TABS = ['general', 'clock', 'background', 'weather', 'quotes', 'links', 'apps', 'account'] as const;
 export type SettingsTab = typeof TABS[number];
 
 const LABELS: Record<SettingsTab, string> = {
@@ -10,13 +8,9 @@ const LABELS: Record<SettingsTab, string> = {
   weather: 'Weather',
   quotes: 'Quotes',
   links: 'Links',
-  calendar: 'Calendar',
-  spotify: 'Spotify',
+  apps: 'Apps',
   account: 'Account',
 };
-
-/** Tabs that require a signed-in user to be interactive */
-const AUTH_REQUIRED_TABS = new Set<SettingsTab>(['calendar']);
 
 interface SettingsNavProps {
   active: SettingsTab;
@@ -24,25 +18,17 @@ interface SettingsNavProps {
 }
 
 export function SettingsNav({ active, onChange }: SettingsNavProps) {
-  const { user } = useAuth();
-
   return (
     <div className="settings-nav">
-      {TABS.map((tab) => {
-        const locked = AUTH_REQUIRED_TABS.has(tab) && !user;
-        return (
-          <button
-            key={tab}
-            onClick={() => onChange(tab)}
-            disabled={locked}
-            title={locked ? 'Sign in to access' : undefined}
-            className={`settings-nav-btn ${active === tab ? 'active' : ''} ${locked ? 'locked' : ''}`}
-          >
-            {LABELS[tab]}
-            {locked && <span className="settings-nav-lock">🔒</span>}
-          </button>
-        );
-      })}
+      {TABS.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => onChange(tab)}
+          className={`settings-nav-btn ${active === tab ? 'active' : ''}`}
+        >
+          {LABELS[tab]}
+        </button>
+      ))}
     </div>
   );
 }

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import { QuotesSettings } from "./sections/QuotesSettings";
 import { LinksSettings } from "./sections/LinksSettings";
 import { AppHub, type AppId } from "./sections/AppHub";
 import { AppCenterPanel } from "./sections/AppCenterPanel";
+import { TemplatesGallery } from "./sections/TemplatesGallery";
 import { AccountSettings } from "./sections/AccountSettings";
 
 export function SettingsPanel() {
@@ -92,6 +93,7 @@ export function SettingsPanel() {
               {activeTab === "apps" && (
                 <AppHub onOpenApp={setOpenAppId} />
               )}
+              {activeTab === "templates" && <TemplatesGallery />}
               {activeTab === "account" && <AccountSettings />}
             </div>
           </div>

--- a/web/src/components/settings/SettingsPanel.tsx
+++ b/web/src/components/settings/SettingsPanel.tsx
@@ -10,14 +10,15 @@ import { BackgroundSettings } from "./sections/BackgroundSettings";
 import { WeatherSettings } from "./sections/WeatherSettings";
 import { QuotesSettings } from "./sections/QuotesSettings";
 import { LinksSettings } from "./sections/LinksSettings";
-import { CalendarSettings } from "./sections/CalendarSettings";
-import { SpotifySettings } from "./sections/SpotifySettings";
+import { AppHub, type AppId } from "./sections/AppHub";
+import { AppCenterPanel } from "./sections/AppCenterPanel";
 import { AccountSettings } from "./sections/AccountSettings";
 
 export function SettingsPanel() {
   const { reset } = useSettings();
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<SettingsTab>("general");
+  const [openAppId, setOpenAppId] = useState<AppId | null>(null);
 
   useEffect(() => {
     const toggleHandler = () => {
@@ -42,6 +43,7 @@ export function SettingsPanel() {
   }, []);
 
   const close = useCallback(() => setIsOpen(false), []);
+  const closeApp = useCallback(() => setOpenAppId(null), []);
 
   const handleReset = useCallback(async () => {
     if (
@@ -87,8 +89,9 @@ export function SettingsPanel() {
               {activeTab === "weather" && <WeatherSettings />}
               {activeTab === "quotes" && <QuotesSettings />}
               {activeTab === "links" && <LinksSettings />}
-              {activeTab === "calendar" && <CalendarSettings />}
-              {activeTab === "spotify" && <SpotifySettings />}
+              {activeTab === "apps" && (
+                <AppHub onOpenApp={setOpenAppId} />
+              )}
               {activeTab === "account" && <AccountSettings />}
             </div>
           </div>
@@ -106,6 +109,11 @@ export function SettingsPanel() {
           </button>
         </div>
       </div>
+
+      {/* App center panel — centered overlay above settings */}
+      {openAppId && (
+        <AppCenterPanel appId={openAppId} onClose={closeApp} />
+      )}
     </>
   );
 }

--- a/web/src/components/settings/sections/AppCenterPanel.tsx
+++ b/web/src/components/settings/sections/AppCenterPanel.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react';
+import { X } from 'lucide-react';
+import type { AppId } from './AppHub';
+import { CalendarSettings } from './CalendarSettings';
+import { SpotifySettings } from './SpotifySettings';
+
+const APP_LABELS: Record<AppId, string> = {
+  calendar: 'Calendar',
+  spotify: 'Spotify',
+};
+
+function CalendarIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+
+function SpotifyIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="#1DB954">
+      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+    </svg>
+  );
+}
+
+const APP_ICONS: Record<AppId, React.ReactNode> = {
+  calendar: <CalendarIcon />,
+  spotify: <SpotifyIcon />,
+};
+
+interface AppCenterPanelProps {
+  appId: AppId;
+  onClose: () => void;
+}
+
+export function AppCenterPanel({ appId, onClose }: AppCenterPanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKey);
+    panelRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <>
+      <div className="app-center-backdrop" onClick={onClose} aria-hidden="true" />
+      <div
+        ref={panelRef}
+        className="app-center-panel glass-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${APP_LABELS[appId]} settings`}
+        tabIndex={-1}
+      >
+        <div className="app-center-header">
+          <div className="app-center-title">
+            <span className="app-center-icon">{APP_ICONS[appId]}</span>
+            <span className="app-center-name">{APP_LABELS[appId]}</span>
+          </div>
+          <button
+            type="button"
+            className="app-center-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <div className="app-center-body">
+          {appId === 'calendar' && <CalendarSettings />}
+          {appId === 'spotify' && <SpotifySettings />}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/settings/sections/AppHub.tsx
+++ b/web/src/components/settings/sections/AppHub.tsx
@@ -1,0 +1,80 @@
+import { useSettings } from '../../../contexts/SettingsContext';
+
+export type AppId = 'calendar' | 'spotify';
+
+interface AppDef {
+  id: AppId;
+  label: string;
+  icon: React.ReactNode;
+  connected: (settings: ReturnType<typeof useSettings>['settings']) => boolean;
+}
+
+function CalendarIcon() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+
+function SpotifyIcon() {
+  return (
+    <svg width="28" height="28" viewBox="0 0 24 24" fill="#1DB954">
+      <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+    </svg>
+  );
+}
+
+const APP_DEFS: AppDef[] = [
+  {
+    id: 'calendar',
+    label: 'Calendar',
+    icon: <CalendarIcon />,
+    connected: (s) => s.integrations.calendar.connected,
+  },
+  {
+    id: 'spotify',
+    label: 'Spotify',
+    icon: <SpotifyIcon />,
+    connected: (s) => s.integrations.spotify.connected,
+  },
+];
+
+interface AppHubProps {
+  onOpenApp: (id: AppId) => void;
+}
+
+export function AppHub({ onOpenApp }: AppHubProps) {
+  const { settings } = useSettings();
+
+  return (
+    <div className="app-hub">
+      <p className="settings-hint" style={{ marginBottom: '16px' }}>
+        Connect and manage your integrations. Click an app to configure it.
+      </p>
+      <div className="app-hub-grid">
+        {APP_DEFS.map((app) => {
+          const isConnected = app.connected(settings);
+          return (
+            <button
+              key={app.id}
+              type="button"
+              className="app-hub-card"
+              onClick={() => onOpenApp(app.id)}
+              aria-label={`${app.label} — ${isConnected ? 'connected' : 'not connected'}`}
+            >
+              <div className="app-hub-icon">{app.icon}</div>
+              <span className="app-hub-label">{app.label}</span>
+              <span className={`app-hub-badge${isConnected ? ' connected' : ''}`}>
+                {isConnected ? 'Connected' : 'Not connected'}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/sections/AppHub.tsx
+++ b/web/src/components/settings/sections/AppHub.tsx
@@ -53,7 +53,7 @@ export function AppHub({ onOpenApp }: AppHubProps) {
   return (
     <div className="app-hub">
       <p className="settings-hint" style={{ marginBottom: '16px' }}>
-        Connect and manage your integrations. Click an app to configure it.
+        Click an app to configure it.
       </p>
       <div className="app-hub-grid">
         {APP_DEFS.map((app) => {
@@ -67,10 +67,7 @@ export function AppHub({ onOpenApp }: AppHubProps) {
               aria-label={`${app.label} — ${isConnected ? 'connected' : 'not connected'}`}
             >
               <div className="app-hub-icon">{app.icon}</div>
-              <span className="app-hub-label">{app.label}</span>
-              <span className={`app-hub-badge${isConnected ? ' connected' : ''}`}>
-                {isConnected ? 'Connected' : 'Not connected'}
-              </span>
+              <span className={`app-hub-dot${isConnected ? ' connected' : ''}`} aria-hidden="true" />
             </button>
           );
         })}

--- a/web/src/components/settings/sections/AppHub.tsx
+++ b/web/src/components/settings/sections/AppHub.tsx
@@ -66,8 +66,10 @@ export function AppHub({ onOpenApp }: AppHubProps) {
               onClick={() => onOpenApp(app.id)}
               aria-label={`${app.label} — ${isConnected ? 'connected' : 'not connected'}`}
             >
-              <div className="app-hub-icon">{app.icon}</div>
-              <span className={`app-hub-dot${isConnected ? ' connected' : ''}`} aria-hidden="true" />
+              <div className="app-hub-icon">
+                {app.icon}
+                <span className={`app-hub-dot${isConnected ? ' connected' : ''}`} aria-hidden="true" />
+              </div>
             </button>
           );
         })}

--- a/web/src/components/settings/sections/BackgroundSettings.tsx
+++ b/web/src/components/settings/sections/BackgroundSettings.tsx
@@ -11,7 +11,7 @@ const MAX_UPLOAD_BYTES = 5 * 1024 * 1024;
 
 export function BackgroundSettings() {
   const { settings, update } = useSettings();
-  const { addLocalPhoto, setFromPhoto, setUploadedBackground, photoHistory } = useBackgroundContext();
+  const { addLocalPhoto, setFromPhoto, setUploadedBackground, photoHistory, unsplashError } = useBackgroundContext();
   const { unsplashHistory, localHistory, liked, toggleLike, deleteLocalPhoto } = photoHistory;
   const [uploading, setUploading] = useState(false);
 
@@ -81,20 +81,31 @@ export function BackgroundSettings() {
       {/* Unsplash settings */}
       {isUnsplash && (
         <>
+          {unsplashError === 'no-key' && (
+            <div className="auth-required-notice" style={{ marginBottom: '8px' }}>
+              <p>Enter your Unsplash Access Key below to load photos. Without a key a gradient is shown.</p>
+            </div>
+          )}
+          {unsplashError && unsplashError !== 'no-key' && (
+            <div className="auth-required-notice" style={{ marginBottom: '8px', borderColor: 'rgba(248,113,113,0.4)' }}>
+              <p style={{ color: 'rgba(248,113,113,0.9)' }}>{unsplashError}</p>
+            </div>
+          )}
           <div className="settings-group">
-            <label className="settings-label">Unsplash API Key (optional):</label>
+            <label className="settings-label">Unsplash Access Key:</label>
             <input
               type="text"
               defaultValue={settings.background.unsplashApiKey}
-              placeholder="Your API key"
+              placeholder="Paste your Access Key here"
               onChange={(e) => update('background', { unsplashApiKey: e.target.value })}
               className="settings-input glass-input"
             />
             <small className="settings-hint">
-              Get your key at{' '}
+              Get a free key at{' '}
               <a href="https://unsplash.com/developers" target="_blank" rel="noopener noreferrer">
                 unsplash.com/developers
               </a>
+              {' '}→ create an app → copy the Access Key.
             </small>
           </div>
           <div className="settings-group">

--- a/web/src/components/settings/sections/TemplatesGallery.tsx
+++ b/web/src/components/settings/sections/TemplatesGallery.tsx
@@ -4,7 +4,7 @@ import { TEMPLATES, type SettingsTemplate } from '../../../lib/templates';
 
 function TemplateCard({ template, onApply }: { template: SettingsTemplate; onApply: () => void }) {
   return (
-    <div className="template-card">
+    <div className="template-card" style={{ '--template-accent': template.accent } as React.CSSProperties}>
       <div className="template-thumbnail">
         <img src={template.thumbnail} alt={template.name} draggable={false} />
       </div>
@@ -25,7 +25,7 @@ export function TemplatesGallery() {
 
   function handleApply(template: SettingsTemplate) {
     const sectionNames = Object.keys(template.settings).join(', ');
-    if (!confirm(`Apply the "${template.name}" template? This will overwrite your settings for: ${sectionNames}.`)) return;
+    if (!confirm(`Apply "${template.name}"? This overwrites your settings for: ${sectionNames}.`)) return;
 
     void updateMultiple(template.settings as Parameters<typeof updateMultiple>[0]);
     setApplied(template.id);
@@ -35,7 +35,7 @@ export function TemplatesGallery() {
   return (
     <div className="templates-gallery">
       <p className="settings-hint" style={{ marginBottom: '16px' }}>
-        Start with a preset layout. Applying a template only overwrites the sections it defines — your other settings are untouched.
+        Preset layouts — only overwrites the sections shown. Your links, API keys, and other settings stay.
       </p>
       <div className="templates-grid">
         {TEMPLATES.map((t) => (

--- a/web/src/components/settings/sections/TemplatesGallery.tsx
+++ b/web/src/components/settings/sections/TemplatesGallery.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { useSettings } from '../../../contexts/SettingsContext';
+import { TEMPLATES, type SettingsTemplate } from '../../../lib/templates';
+
+function TemplateCard({ template, onApply }: { template: SettingsTemplate; onApply: () => void }) {
+  return (
+    <div className="template-card">
+      <div className="template-thumbnail">
+        <img src={template.thumbnail} alt={template.name} draggable={false} />
+      </div>
+      <div className="template-info">
+        <span className="template-name">{template.name}</span>
+        <span className="template-desc">{template.description}</span>
+      </div>
+      <button type="button" className="template-apply-btn" onClick={onApply}>
+        Apply
+      </button>
+    </div>
+  );
+}
+
+export function TemplatesGallery() {
+  const { updateMultiple } = useSettings();
+  const [applied, setApplied] = useState<string | null>(null);
+
+  function handleApply(template: SettingsTemplate) {
+    const sectionNames = Object.keys(template.settings).join(', ');
+    if (!confirm(`Apply the "${template.name}" template? This will overwrite your settings for: ${sectionNames}.`)) return;
+
+    void updateMultiple(template.settings as Parameters<typeof updateMultiple>[0]);
+    setApplied(template.id);
+    setTimeout(() => setApplied(null), 2500);
+  }
+
+  return (
+    <div className="templates-gallery">
+      <p className="settings-hint" style={{ marginBottom: '16px' }}>
+        Start with a preset layout. Applying a template only overwrites the sections it defines — your other settings are untouched.
+      </p>
+      <div className="templates-grid">
+        {TEMPLATES.map((t) => (
+          <div key={t.id} style={{ position: 'relative' }}>
+            <TemplateCard template={t} onApply={() => handleApply(t)} />
+            {applied === t.id && (
+              <div className="template-applied-badge">Applied!</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/weather/WeatherWidget.tsx
+++ b/web/src/components/weather/WeatherWidget.tsx
@@ -11,11 +11,16 @@ export function WeatherWidget() {
 
   if (!settings.weather.show) return null;
 
-  if (state.status === 'placeholder') {
+  const unit = settings.weather.unit ?? 'F';
+
+  if (state.status === 'placeholder' || state.status === 'error') {
     return (
       <div className="weather-widget glass-dock text-shadow-sm">
-        <Thermometer size={28} className="weather-icon" />
-        <span className="weather-city">{state.message}</span>
+        <div className="weather-circle">
+          {state.status === 'error'
+            ? <AlertTriangle size={18} style={{ opacity: 0.6 }} />
+            : <Thermometer size={18} style={{ opacity: 0.5 }} />}
+        </div>
       </div>
     );
   }
@@ -23,16 +28,9 @@ export function WeatherWidget() {
   if (state.status === 'loading') {
     return (
       <div className="weather-widget glass-dock text-shadow-sm">
-        <Thermometer size={28} className="weather-icon" />
-        <span className="weather-temp">...</span>
-      </div>
-    );
-  }
-
-  if (state.status === 'error') {
-    return (
-      <div className="weather-widget glass-dock text-shadow-sm weather-error">
-        <AlertTriangle size={28} className="weather-icon" />
+        <div className="weather-circle">
+          <span className="weather-temp">…</span>
+        </div>
       </div>
     );
   }
@@ -44,12 +42,17 @@ export function WeatherWidget() {
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
     >
-      <WeatherIcon iconCode={state.data.iconCode} condition={state.data.condition} isDay={state.data.isDay} size={28} className="weather-icon" />
-      <span className="weather-temp">{state.displayTemp}&deg;</span>
+      <div className="weather-circle">
+        <span className="weather-temp">{state.displayTemp}</span>
+        <span className="weather-unit">{unit}</span>
+      </div>
       <div className="weather-expand">
         <div className="weather-expand-inner">
-          <span className="weather-city">{state.data.city}</span>
-          <span className="weather-condition">{state.data.condition}</span>
+          <WeatherIcon iconCode={state.data.iconCode} condition={state.data.condition} isDay={state.data.isDay} size={22} className="weather-icon" />
+          <div className="weather-detail">
+            <span className="weather-city">{state.data.city}</span>
+            <span className="weather-condition">{state.data.condition}</span>
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/components/weather/WeatherWidget.tsx
+++ b/web/src/components/weather/WeatherWidget.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useWeather } from '../../hooks/useWeather';
 import { useSettings } from '../../contexts/SettingsContext';
 import { WeatherIcon } from './WeatherIcon';
@@ -6,6 +7,7 @@ import { Thermometer, AlertTriangle } from 'lucide-react';
 export function WeatherWidget() {
   const { settings } = useSettings();
   const state = useWeather();
+  const [hovered, setHovered] = useState(false);
 
   if (!settings.weather.show) return null;
 
@@ -23,7 +25,6 @@ export function WeatherWidget() {
       <div className="weather-widget glass-dock text-shadow-sm">
         <Thermometer size={28} className="weather-icon" />
         <span className="weather-temp">...</span>
-        <span className="weather-city">Loading...</span>
       </div>
     );
   }
@@ -32,17 +33,25 @@ export function WeatherWidget() {
     return (
       <div className="weather-widget glass-dock text-shadow-sm weather-error">
         <AlertTriangle size={28} className="weather-icon" />
-        <span className="weather-city">Error</span>
       </div>
     );
   }
 
   // status === 'ready'
   return (
-    <div className="weather-widget glass-dock text-shadow-sm">
+    <div
+      className={`weather-widget glass-dock text-shadow-sm${hovered ? ' weather-widget--open' : ''}`}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
       <WeatherIcon iconCode={state.data.iconCode} condition={state.data.condition} isDay={state.data.isDay} size={28} className="weather-icon" />
       <span className="weather-temp">{state.displayTemp}&deg;</span>
-      <span className="weather-city">{state.data.city}</span>
+      <div className="weather-expand">
+        <div className="weather-expand-inner">
+          <span className="weather-city">{state.data.city}</span>
+          <span className="weather-condition">{state.data.condition}</span>
+        </div>
+      </div>
     </div>
   );
 }

--- a/web/src/contexts/BackgroundContext.tsx
+++ b/web/src/contexts/BackgroundContext.tsx
@@ -27,6 +27,7 @@ interface BackgroundContextValue {
   photographer: { name: string; url: string } | null;
   currentPhotoId: string | null;
   currentPhotoSource: 'unsplash' | 'local' | 'bundled' | null;
+  unsplashError: string | null;
   refresh: () => Promise<void>;
   setFromPhoto: (photo: PhotoRecord) => Promise<void>;
   setFromLocalPhoto: (id: string) => Promise<void>;
@@ -44,6 +45,7 @@ export function BackgroundProvider({ children }: { children: ReactNode }) {
   const [photographer, setPhotographer] = useState<{ name: string; url: string } | null>(null);
   const [currentPhotoId, setCurrentPhotoId] = useState<string | null>(null);
   const [currentPhotoSource, setCurrentPhotoSource] = useState<'unsplash' | 'local' | 'bundled' | null>(null);
+  const [unsplashError, setUnsplashError] = useState<string | null>(null);
   const photoHistory = usePhotoHistory();
 
   // Per-user storage key: isolates each account's local background on this device.
@@ -124,6 +126,8 @@ export function BackgroundProvider({ children }: { children: ReactNode }) {
   }, [bgImageKey, applyBackground]);
 
   const loadUnsplash = useCallback(async () => {
+    setUnsplashError(null);
+
     const cached = await ls.get<UnsplashCache | null>('unsplashCache', null);
     if (cached && Date.now() - cached.timestamp < CACHE_DURATION) {
       applyBackground(cached.imageUrl);
@@ -137,18 +141,34 @@ export function BackgroundProvider({ children }: { children: ReactNode }) {
       applyBackground(DEFAULT_GRADIENT);
       setPhotographer(null);
       setCurrentPhotoSource(null);
+      setUnsplashError('no-key');
       return;
     }
 
     try {
-      const res = await fetch(`${UNSPLASH_API_URL}?orientation=landscape&query=nature`, {
+      const params = new URLSearchParams({ orientation: 'landscape' });
+      if (settings.background.unsplashCollectionId?.trim()) {
+        params.set('collections', settings.background.unsplashCollectionId.trim());
+      } else {
+        params.set('query', 'nature');
+      }
+
+      const res = await fetch(`${UNSPLASH_API_URL}?${params.toString()}`, {
         headers: { Authorization: `Client-ID ${settings.background.unsplashApiKey}` },
       });
-      if (!res.ok) throw new Error(`Unsplash API error: ${res.status}`);
-      const data = await res.json();
+
+      if (res.status === 401) throw new Error('Invalid API key — check your Unsplash Access Key.');
+      if (res.status === 403) throw new Error('Unsplash rate limit reached. Try again later.');
+      if (!res.ok) throw new Error(`Unsplash API error ${res.status}`);
+
+      const data = await res.json() as {
+        id: string;
+        urls: { regular: string; small: string };
+        user: { name: string; links: { html: string } };
+      };
 
       const imageData: UnsplashCache = {
-        imageUrl: data.urls.full,
+        imageUrl: data.urls.regular,
         thumbUrl: data.urls.small,
         photographer: data.user.name,
         photographerUrl: data.user.links.html,
@@ -170,13 +190,15 @@ export function BackgroundProvider({ children }: { children: ReactNode }) {
         photographerUrl: imageData.photographerUrl,
       });
     } catch (error) {
-      console.error('Error loading Unsplash image:', error);
+      const msg = error instanceof Error ? error.message : 'Failed to load Unsplash photo';
+      console.warn('[BackgroundContext] Unsplash error:', msg);
       applyBackground(DEFAULT_GRADIENT);
       setPhotographer(null);
       setCurrentPhotoSource(null);
+      setUnsplashError(msg);
     }
   // addPhoto is a stable useCallback - safe dep; do NOT add photoHistory here
-  }, [settings.background.unsplashApiKey, applyBackground, addPhoto]);
+  }, [settings.background.unsplashApiKey, settings.background.unsplashCollectionId, applyBackground, addPhoto]);
 
   const loadLocal = useCallback(async () => {
     let localImage = await ls.get<string | null>(bgImageKey, null);
@@ -228,6 +250,7 @@ export function BackgroundProvider({ children }: { children: ReactNode }) {
       photographer,
       currentPhotoId,
       currentPhotoSource,
+      unsplashError,
       refresh,
       setFromPhoto,
       setFromLocalPhoto,

--- a/web/src/lib/templates.ts
+++ b/web/src/lib/templates.ts
@@ -5,6 +5,7 @@ export interface SettingsTemplate {
   name: string;
   description: string;
   thumbnail: string;
+  accent: string;
   settings: DeepPartial<Settings>;
 }
 
@@ -16,63 +17,73 @@ export const TEMPLATES: SettingsTemplate[] = [
   {
     id: 'minimal',
     name: 'Minimal',
-    description: 'Clean and distraction-free. Clock only, no widgets.',
+    description: 'Clean slate — just the clock.',
     thumbnail: '/templates/minimal.svg',
+    accent: '#6366f1',
     settings: {
-      clock: {
-        style: 'default',
-        weight: 200,
-        size: 140,
-        showDate: false,
-      },
+      clock: { style: 'default', weight: 200, size: 140, showDate: false },
       weather: { show: false },
-      widgets: {
-        showLinks: false,
-        showFocus: false,
-        showQuotes: false,
-      },
+      widgets: { showLinks: false, showFocus: false, showQuotes: false },
     },
   },
   {
     id: 'productivity',
     name: 'Productivity',
-    description: 'Focus-first layout with quick links, tasks, and calendar.',
+    description: 'Date, links, focus bar — all business.',
     thumbnail: '/templates/productivity.svg',
+    accent: '#22d3ee',
     settings: {
-      clock: {
-        style: 'default',
-        weight: 200,
-        size: 120,
-        showDate: true,
-        dateFormat: 'long',
-      },
+      clock: { style: 'default', weight: 200, size: 120, showDate: true, dateFormat: 'long' },
       weather: { show: true },
-      widgets: {
-        showLinks: true,
-        showFocus: true,
-        showQuotes: false,
-      },
+      widgets: { showLinks: true, showFocus: true, showQuotes: false },
     },
   },
   {
     id: 'inspiration',
     name: 'Inspiration',
-    description: 'Daily quotes front and center. Perfect for a motivational start.',
+    description: 'Daily quotes front and center.',
     thumbnail: '/templates/inspiration.svg',
+    accent: '#f59e0b',
     settings: {
-      clock: {
-        style: 'glass',
-        weight: 100,
-        size: 110,
-        showDate: false,
-      },
+      clock: { style: 'glass', weight: 100, size: 110, showDate: false },
       weather: { show: true },
-      widgets: {
-        showLinks: false,
-        showFocus: false,
-        showQuotes: true,
-        quoteSource: 'local',
-      },
+      widgets: { showLinks: false, showFocus: false, showQuotes: true, quoteSource: 'local' },
+    },
+  },
+  {
+    id: 'dashboard',
+    name: 'Dashboard',
+    description: 'Everything on. Max info density.',
+    thumbnail: '/templates/dashboard.svg',
+    accent: '#4ade80',
+    settings: {
+      clock: { style: 'default', weight: 400, size: 100, showDate: true, dateFormat: 'long' },
+      weather: { show: true },
+      widgets: { showLinks: true, showFocus: true, showQuotes: true, quoteSource: 'local' },
+    },
+  },
+  {
+    id: 'night',
+    name: 'Night Owl',
+    description: 'Bold outline clock, no distractions.',
+    thumbnail: '/templates/night.svg',
+    accent: '#a78bfa',
+    settings: {
+      clock: { style: 'outline', weight: 100, size: 130, showDate: false, color: '#a78bfa' },
+      weather: { show: false },
+      widgets: { showLinks: false, showFocus: true, showQuotes: false },
+    },
+  },
+  {
+    id: 'focus-only',
+    name: 'Deep Focus',
+    description: 'Just your intention for today.',
+    thumbnail: '/templates/focus-only.svg',
+    accent: '#fb7185',
+    settings: {
+      clock: { style: 'default', weight: 200, size: 90, showDate: false },
+      weather: { show: false },
+      widgets: { showLinks: false, showFocus: true, showQuotes: false },
     },
   },
 ];

--- a/web/src/lib/templates.ts
+++ b/web/src/lib/templates.ts
@@ -1,0 +1,78 @@
+import type { Settings } from '../types/settings';
+
+export interface SettingsTemplate {
+  id: string;
+  name: string;
+  description: string;
+  thumbnail: string;
+  settings: DeepPartial<Settings>;
+}
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+export const TEMPLATES: SettingsTemplate[] = [
+  {
+    id: 'minimal',
+    name: 'Minimal',
+    description: 'Clean and distraction-free. Clock only, no widgets.',
+    thumbnail: '/templates/minimal.svg',
+    settings: {
+      clock: {
+        style: 'default',
+        weight: 200,
+        size: 140,
+        showDate: false,
+      },
+      weather: { show: false },
+      widgets: {
+        showLinks: false,
+        showFocus: false,
+        showQuotes: false,
+      },
+    },
+  },
+  {
+    id: 'productivity',
+    name: 'Productivity',
+    description: 'Focus-first layout with quick links, tasks, and calendar.',
+    thumbnail: '/templates/productivity.svg',
+    settings: {
+      clock: {
+        style: 'default',
+        weight: 200,
+        size: 120,
+        showDate: true,
+        dateFormat: 'long',
+      },
+      weather: { show: true },
+      widgets: {
+        showLinks: true,
+        showFocus: true,
+        showQuotes: false,
+      },
+    },
+  },
+  {
+    id: 'inspiration',
+    name: 'Inspiration',
+    description: 'Daily quotes front and center. Perfect for a motivational start.',
+    thumbnail: '/templates/inspiration.svg',
+    settings: {
+      clock: {
+        style: 'glass',
+        weight: 100,
+        size: 110,
+        showDate: false,
+      },
+      weather: { show: true },
+      widgets: {
+        showLinks: false,
+        showFocus: false,
+        showQuotes: true,
+        quoteSource: 'local',
+      },
+    },
+  },
+];

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3056,6 +3056,139 @@ body.focus-exiting .sidebar-container {
 }
 
 /* ============================================================
+   App Hub
+   ============================================================ */
+.app-hub {
+  display: flex;
+  flex-direction: column;
+}
+.app-hub-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+.app-hub-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 8px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(8px);
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease;
+  color: inherit;
+  font-family: inherit;
+}
+.app-hub-card:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.2);
+  transform: translateY(-2px);
+}
+.app-hub-card:active {
+  transform: translateY(0);
+}
+.app-hub-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.85);
+}
+.app-hub-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.9);
+}
+.app-hub-badge {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.45);
+}
+.app-hub-badge.connected {
+  color: #4ade80;
+}
+
+/* ============================================================
+   App Center Panel
+   ============================================================ */
+.app-center-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  backdrop-filter: blur(4px);
+  z-index: 1100;
+}
+.app-center-panel {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 1101;
+  width: min(460px, calc(100vw - 32px));
+  max-height: min(600px, calc(100vh - 40px));
+  display: flex;
+  flex-direction: column;
+  border-radius: 20px;
+  overflow: hidden;
+  outline: none;
+}
+.app-center-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  flex-shrink: 0;
+}
+.app-center-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.app-center-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+}
+.app-center-name {
+  font-size: 16px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+.app-center-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  padding: 0;
+}
+.app-center-close:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: white;
+}
+.app-center-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+/* ============================================================
    Integration Cards (Calendar, Spotify)
    ============================================================ */
 .integration-card {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3189,6 +3189,90 @@ body.focus-exiting .sidebar-container {
 }
 
 /* ============================================================
+   Templates Gallery
+   ============================================================ */
+.templates-gallery {
+  display: flex;
+  flex-direction: column;
+}
+.templates-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+.template-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+  overflow: hidden;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+.template-card:hover {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.07);
+}
+.template-thumbnail {
+  width: 100%;
+  aspect-ratio: 3 / 2;
+  overflow: hidden;
+  background: rgba(0, 0, 0, 0.3);
+}
+.template-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.template-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0 12px;
+}
+.template-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.9);
+}
+.template-desc {
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.5);
+  line-height: 1.4;
+}
+.template-apply-btn {
+  margin: 0 12px 12px;
+  padding: 8px 0;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.8);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.template-apply-btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+  border-color: rgba(255, 255, 255, 0.25);
+  color: white;
+}
+.template-applied-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  padding: 4px 10px;
+  border-radius: 20px;
+  background: #4ade80;
+  color: #052e16;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* ============================================================
    Integration Cards (Calendar, Spotify)
    ============================================================ */
 .integration-card {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -449,54 +449,77 @@ input[type="file"]::file-selector-button:hover {
 /* ============================================================
    Weather Widget
    ============================================================ */
+/* ── Outer pill — starts as a circle, grows on hover ───────── */
 .weather-widget {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 16px;
-  border-radius: 23px;
-  height: 46px;
+  height: 52px;
+  border-radius: 26px;
   overflow: hidden;
+  padding: 0;
+  gap: 0;
   transition:
-    width 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
-    border-radius 0.35s ease;
+    border-radius 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
 }
 .weather-widget--open {
   border-radius: 16px;
 }
-.weather-widget .weather-icon {
+
+/* ── Circle core — always visible ─────────────────────────── */
+.weather-circle {
+  position: relative;
+  width: 52px;
+  height: 52px;
   flex-shrink: 0;
-}
-.weather-widget .weather-temp {
-  font-size: 20px;
-  font-weight: 400;
   display: flex;
   align-items: center;
-  flex-shrink: 0;
+  justify-content: center;
+}
+.weather-widget .weather-temp {
+  font-size: 19px;
+  font-weight: 400;
+  line-height: 1;
+}
+.weather-widget .weather-unit {
+  position: absolute;
+  top: 9px;
+  right: 8px;
+  font-size: 9px;
+  font-weight: 600;
+  opacity: 0.55;
+  letter-spacing: 0.02em;
 }
 
-/* Expandable detail panel — hidden until hover */
+/* ── Expandable detail — hidden until hover ───────────────── */
 .weather-expand {
-  flex: 1;
-  min-width: 0;
+  max-width: 0;
   overflow: hidden;
   opacity: 0;
   pointer-events: none;
-  max-width: 0;
-  transition: opacity 0.18s ease, max-width 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition:
+    max-width 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    opacity 0.18s ease;
 }
 .weather-widget--open .weather-expand {
+  max-width: 200px;
   opacity: 1;
   pointer-events: auto;
-  max-width: 160px;
 }
 .weather-expand-inner {
   display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 1px;
-  padding-left: 2px;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px 0 4px;
   white-space: nowrap;
+}
+.weather-widget .weather-icon {
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+.weather-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
 }
 .weather-widget .weather-city {
   font-size: 12px;
@@ -504,15 +527,11 @@ input[type="file"]::file-selector-button:hover {
   opacity: 0.9;
 }
 .weather-widget .weather-condition {
-  font-size: 11px;
-  opacity: 0.65;
+  font-size: 10px;
+  opacity: 0.55;
 }
-.weather-error {
-  opacity: 0.7;
-}
-.weather-placeholder {
-  opacity: 0.7;
-}
+.weather-error { opacity: 0.6; }
+.weather-placeholder { opacity: 0.6; }
 
 /* City autocomplete dropdown */
 .city-dropdown {
@@ -3064,16 +3083,18 @@ body.focus-exiting .sidebar-container {
 }
 .app-hub-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 12px;
 }
 .app-hub-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 16px 8px 14px;
-  border-radius: 14px;
+  justify-content: center;
+  gap: 10px;
+  padding: 18px 8px 16px;
+  border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.05);
   backdrop-filter: blur(8px);
@@ -3081,10 +3102,11 @@ body.focus-exiting .sidebar-container {
   transition: background 0.18s ease, border-color 0.18s ease, transform 0.15s ease;
   color: inherit;
   font-family: inherit;
+  aspect-ratio: 1;
 }
 .app-hub-card:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.11);
+  border-color: rgba(255, 255, 255, 0.22);
   transform: translateY(-2px);
 }
 .app-hub-card:active {
@@ -3094,23 +3116,25 @@ body.focus-exiting .sidebar-container {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 48px;
-  height: 48px;
-  border-radius: 12px;
+  width: 52px;
+  height: 52px;
+  border-radius: 14px;
   background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.85);
 }
-.app-hub-label {
-  font-size: 13px;
-  font-weight: 500;
-  color: rgba(255, 255, 255, 0.9);
+/* Connection status dot — bottom-right of card */
+.app-hub-dot {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.25);
 }
-.app-hub-badge {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.45);
-}
-.app-hub-badge.connected {
-  color: #4ade80;
+.app-hub-dot.connected {
+  background: #4ade80;
+  box-shadow: 0 0 6px rgba(74, 222, 128, 0.6);
 }
 
 /* ============================================================
@@ -3198,27 +3222,28 @@ body.focus-exiting .sidebar-container {
 .templates-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
+  gap: 12px;
+  align-items: start;
 }
 .template-card {
   display: flex;
   flex-direction: column;
-  gap: 10px;
   border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.04);
   overflow: hidden;
-  transition: border-color 0.18s ease, background 0.18s ease;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.15s ease;
 }
 .template-card:hover {
-  border-color: rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.07);
+  border-color: color-mix(in srgb, var(--template-accent, #fff) 40%, transparent);
+  background: rgba(255, 255, 255, 0.06);
+  transform: translateY(-1px);
 }
 .template-thumbnail {
   width: 100%;
   aspect-ratio: 3 / 2;
   overflow: hidden;
-  background: rgba(0, 0, 0, 0.3);
+  flex-shrink: 0;
 }
 .template-thumbnail img {
   width: 100%;
@@ -3229,47 +3254,48 @@ body.focus-exiting .sidebar-container {
 .template-info {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 0 12px;
+  gap: 3px;
+  padding: 10px 12px 4px;
+  flex: 1;
 }
 .template-name {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   color: rgba(255, 255, 255, 0.9);
 }
 .template-desc {
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.5);
+  font-size: 10.5px;
+  color: rgba(255, 255, 255, 0.45);
   line-height: 1.4;
 }
 .template-apply-btn {
-  margin: 0 12px 12px;
-  padding: 8px 0;
+  margin: 8px 10px 10px;
+  padding: 7px 0;
   border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  background: rgba(255, 255, 255, 0.08);
-  color: rgba(255, 255, 255, 0.8);
-  font-size: 12px;
+  border: 1px solid color-mix(in srgb, var(--template-accent, #fff) 30%, transparent);
+  background: color-mix(in srgb, var(--template-accent, #fff) 10%, transparent);
+  color: color-mix(in srgb, var(--template-accent, #fff) 85%, white);
+  font-size: 11.5px;
   font-weight: 500;
   cursor: pointer;
   font-family: inherit;
+  flex-shrink: 0;
   transition: background 0.15s ease, border-color 0.15s ease;
 }
 .template-apply-btn:hover {
-  background: rgba(255, 255, 255, 0.14);
-  border-color: rgba(255, 255, 255, 0.25);
-  color: white;
+  background: color-mix(in srgb, var(--template-accent, #fff) 20%, transparent);
+  border-color: color-mix(in srgb, var(--template-accent, #fff) 50%, transparent);
 }
 .template-applied-badge {
   position: absolute;
   top: 8px;
   right: 8px;
-  padding: 4px 10px;
+  padding: 3px 9px;
   border-radius: 20px;
   background: #4ade80;
   color: #052e16;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: 10px;
+  font-weight: 700;
 }
 
 /* ============================================================

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -3094,13 +3094,10 @@ body.focus-exiting .sidebar-container {
   gap: 12px;
 }
 .app-hub-card {
-  position: relative;
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 18px 8px 16px;
+  padding: 12px;
   border-radius: 16px;
   border: 1px solid rgba(255, 255, 255, 0.1);
   background: rgba(255, 255, 255, 0.05);
@@ -3120,28 +3117,30 @@ body.focus-exiting .sidebar-container {
   transform: translateY(0);
 }
 .app-hub-icon {
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
   width: 52px;
   height: 52px;
   border-radius: 14px;
-  background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.85);
 }
-/* Connection status dot — bottom-right of card */
+/* Connection status dot — bottom-right corner of icon */
 .app-hub-dot {
   position: absolute;
-  bottom: 10px;
-  right: 10px;
-  width: 7px;
-  height: 7px;
+  bottom: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
   border-radius: 50%;
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.2);
+  border: 1.5px solid rgba(0, 0, 0, 0.3);
 }
 .app-hub-dot.connected {
   background: #4ade80;
-  box-shadow: 0 0 6px rgba(74, 222, 128, 0.6);
+  box-shadow: 0 0 5px rgba(74, 222, 128, 0.7);
+  border-color: rgba(0, 0, 0, 0.25);
 }
 
 /* ============================================================

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -454,8 +454,15 @@ input[type="file"]::file-selector-button:hover {
   align-items: center;
   gap: 10px;
   padding: 8px 16px;
-  border-radius: 18px;
+  border-radius: 23px;
   height: 46px;
+  overflow: hidden;
+  transition:
+    width 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    border-radius 0.35s ease;
+}
+.weather-widget--open {
+  border-radius: 16px;
 }
 .weather-widget .weather-icon {
   flex-shrink: 0;
@@ -465,10 +472,40 @@ input[type="file"]::file-selector-button:hover {
   font-weight: 400;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+}
+
+/* Expandable detail panel — hidden until hover */
+.weather-expand {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  pointer-events: none;
+  max-width: 0;
+  transition: opacity 0.18s ease, max-width 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.weather-widget--open .weather-expand {
+  opacity: 1;
+  pointer-events: auto;
+  max-width: 160px;
+}
+.weather-expand-inner {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1px;
+  padding-left: 2px;
+  white-space: nowrap;
 }
 .weather-widget .weather-city {
   font-size: 12px;
+  font-weight: 500;
   opacity: 0.9;
+}
+.weather-widget .weather-condition {
+  font-size: 11px;
+  opacity: 0.65;
 }
 .weather-error {
   opacity: 0.7;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -2408,16 +2408,23 @@ input[type="checkbox"]:focus-visible {
 .photographer-credit {
   position: fixed;
   bottom: 10px;
-  right: 50%;
-  font-size: 12px;
-  color: rgba(255, 255, 255, 0.8);
-  padding: 8px 12px;
-  border-radius: 10px;
+  left: 62px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 0;
+  font-size: 11.5px;
+  color: rgba(255, 255, 255, 0.55);
   z-index: 50;
   transition: opacity 0.3s;
+  pointer-events: auto;
 }
 .photographer-credit a {
-  color: white;
+  color: rgba(255, 255, 255, 0.75);
+  text-decoration: none;
+}
+.photographer-credit a:hover {
+  color: rgba(255, 255, 255, 1);
   text-decoration: underline;
 }
 .photo-credit-like-btn {


### PR DESCRIPTION
## What
- Collapse weather widget to icon + temp; hover expands rightward to show city + condition (mirrors Spotify dock pattern)
- Replace `calendar` and `spotify` nav tabs with a single `Apps` hub — icon grid with connected/disconnected badges
- App Center Panel: centered overlay that opens on clicking an app card, reuses existing CalendarSettings and SpotifySettings
- Settings Templates gallery with 3 presets (Minimal, Productivity, Inspiration) and SVG preview thumbnails

## Why
The weather widget was always fully expanded, taking more horizontal space than necessary. The settings nav was adding a tab per integration, which doesn't scale. New users had no starting point to understand the dashboard layout — templates bridge that gap.

## How
Weather uses the same `hovered` state + `overflow: hidden` + `transition: max-width` pattern as the Spotify dock. The Apps hub replaces the two removed tabs and maps integration icons to an `onOpenApp` callback in SettingsPanel. AppCenterPanel renders `position: fixed` at z-index 1101 (above the settings panel at 1000) with a blurred backdrop. Templates use `updateMultiple()` with partial section patches — unrelated settings are never touched.

## Test plan
- [ ] Weather widget shows only icon + temp in collapsed state, expands on hover to show city + condition
- [ ] Settings nav has Apps and Templates tabs; calendar and spotify tabs are gone
- [ ] Clicking a card in Apps hub opens App Center Panel with that app's settings
- [ ] App Center Panel closes on ×, Escape, and backdrop click
- [ ] Applying a template in the gallery updates the relevant sections and leaves others unchanged
- [ ] Build passes: `npm run build` in `web/` exits 0

Closes #183, #184, #185, #186

Generated by [Claude-Bot] of [@Yehuda Briskman]