### PR TITLE
feat: add Gmail sidebar widget and integration

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "windom-backend",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "WindoM backend API - Fastify + Drizzle + Postgres",
   "type": "module",
   "engines": {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -17,6 +17,7 @@ import { integrationsRoutes } from './routes/integrations.js';
 import { calendarRoutes } from './routes/calendar.js';
 import { spotifyRoutes } from './routes/spotify.js';
 import { settingsRoutes } from './routes/settings.js';
+import { gmailRoutes } from './routes/gmail.js';
 
 export interface BuildAppOptions extends FastifyServerOptions {
   /** Skip rate limiting - set to true in tests to prevent limit accumulation across test runs. */
@@ -101,6 +102,7 @@ export async function buildApp({ skipRateLimit, ...overrides }: BuildAppOptions 
   await app.register(calendarRoutes, { prefix: '/calendar' });
   await app.register(spotifyRoutes, { prefix: '/spotify' });
   await app.register(settingsRoutes);
+  await app.register(gmailRoutes, { prefix: '/gmail' });
 
   // ── Global error handler ───────────────────────────────────────────────────
 

--- a/backend/src/controllers/gmail.controller.ts
+++ b/backend/src/controllers/gmail.controller.ts
@@ -1,0 +1,20 @@
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import * as gmailService from '../services/gmail.service.js';
+
+export async function getGmailSummaryController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const result = await gmailService.getGmailSummary(req.user.sub);
+
+  if (!result.ok) {
+    if (result.error === 'NOT_CONNECTED') {
+      void reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'Gmail not connected' });
+    } else if (result.error === 'INSUFFICIENT_SCOPES') {
+      void reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'Gmail scope not granted. Please reconnect with Gmail access.' });
+    } else {
+      void reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Could not refresh Google token. Please reconnect.' });
+    }
+    return;
+  }
+
+  reply.header('Cache-Control', 'private, max-age=45');
+  void reply.send(result.data);
+}

--- a/backend/src/controllers/gmail.controller.ts
+++ b/backend/src/controllers/gmail.controller.ts
@@ -5,12 +5,18 @@ export async function getGmailSummaryController(req: FastifyRequest, reply: Fast
   const result = await gmailService.getGmailSummary(req.user.sub);
 
   if (!result.ok) {
+    req.log.warn({ userId: req.user.sub, error: result.error }, '[gmail] getGmailSummary failed');
+
     if (result.error === 'NOT_CONNECTED') {
       void reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'Gmail not connected' });
     } else if (result.error === 'INSUFFICIENT_SCOPES') {
-      void reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'Gmail scope not granted. Please reconnect with Gmail access.' });
+      void reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'Gmail permission not granted. Please disconnect and reconnect via the Gmail settings.' });
+    } else if (result.error === 'GMAIL_API_FORBIDDEN') {
+      void reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'Gmail API access denied. Ensure the Gmail API is enabled in your Google Cloud project and that Gmail permission was granted during sign-in.' });
+    } else if (result.error === 'TOKEN_REFRESH_REVOKED' || result.error === 'TOKEN_REFRESH_FAILED') {
+      void reply.status(403).send({ statusCode: 403, error: 'Forbidden', message: 'Gmail access was revoked. Please disconnect and reconnect via the Gmail settings.' });
     } else {
-      void reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'Could not refresh Google token. Please reconnect.' });
+      void reply.status(503).send({ statusCode: 503, error: 'Service Unavailable', message: 'Could not reach Gmail. Please try again shortly.' });
     }
     return;
   }

--- a/backend/src/controllers/oauth-google.controller.ts
+++ b/backend/src/controllers/oauth-google.controller.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import { config } from '../config.js';
-import { GOOGLE_AUTH_URL, CALENDAR_SCOPES } from '../types/constants.js';
+import { GOOGLE_AUTH_URL, CALENDAR_SCOPES, GMAIL_SCOPES } from '../types/constants.js';
 import * as oauthService from '../services/oauth.service.js';
 import { isAllowedRedirectUri } from '../lib/request.js';
 import { replyOAuthExchangeError } from '../lib/oauth-exchange.js';
@@ -49,11 +49,14 @@ async function handleGoogleOAuthExchange(
 }
 
 export async function startGoogleOAuthController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
-  const { redirectUri, codeChallenge, codeChallengeMethod } = req.query as {
+  const { redirectUri, codeChallenge, codeChallengeMethod, features } = req.query as {
     redirectUri?: string;
     codeChallenge?: string;
     codeChallengeMethod?: string;
+    features?: string;
   };
+  // Use expanded scopes when Gmail access is requested so the token covers both services
+  const scopeSet = features?.includes('gmail') ? GMAIL_SCOPES : CALENDAR_SCOPES;
   const effectiveUri = redirectUri ?? config.GOOGLE_OAUTH_REDIRECT_URI ?? '';
 
   if (!effectiveUri) {
@@ -72,7 +75,7 @@ export async function startGoogleOAuthController(req: FastifyRequest, reply: Fas
     client_id: config.GOOGLE_CLIENT_ID ?? '',
     redirect_uri: effectiveUri,
     response_type: 'code',
-    scope: CALENDAR_SCOPES,
+    scope: scopeSet,
     state,
     access_type: 'offline',
     prompt: 'consent',

--- a/backend/src/controllers/settings.controller.ts
+++ b/backend/src/controllers/settings.controller.ts
@@ -57,6 +57,10 @@ const settingsSectionSchema = z.object({
     spotify: z.object({
       connected: z.boolean(),
     }).partial().optional(),
+    gmail: z.object({
+      connected: z.boolean(),
+      show: z.boolean(),
+    }).partial().optional(),
   }).partial().optional(),
 
   _updatedAt: z.number().optional(),

--- a/backend/src/routes/gmail.ts
+++ b/backend/src/routes/gmail.ts
@@ -1,0 +1,41 @@
+import type { FastifyInstance } from 'fastify';
+import { authenticate } from '../middleware/authenticate.js';
+import { getGmailSummaryController } from '../controllers/gmail.controller.js';
+
+const security = [{ bearerAuth: [] }];
+const errorResponse = { $ref: 'Error#' };
+
+export function gmailRoutes(app: FastifyInstance): void {
+  app.get('/summary', {
+    preHandler: authenticate,
+    schema: {
+      tags: ['Gmail'],
+      summary: 'Get Gmail unread count and recent messages',
+      security,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            unreadCount: { type: 'integer' },
+            messages: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string' },
+                  from: { type: 'string' },
+                  subject: { type: 'string' },
+                  snippet: { type: 'string' },
+                  date: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        401: errorResponse,
+        403: errorResponse,
+        404: errorResponse,
+      },
+    },
+  }, getGmailSummaryController);
+}

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -7,7 +7,7 @@ import { GOOGLE_TOKEN_URL, GMAIL_API, GMAIL_MAX_MESSAGES } from '../types/consta
 import type { Result } from '../types/auth.types.js';
 import type { OAuthError } from '../types/oauth.types.js';
 
-export type GmailError = OAuthError | 'NOT_CONNECTED' | 'INSUFFICIENT_SCOPES';
+export type GmailError = OAuthError | 'NOT_CONNECTED' | 'INSUFFICIENT_SCOPES' | 'GMAIL_API_FORBIDDEN';
 
 export interface GmailMessage {
   id: string;
@@ -87,8 +87,13 @@ export async function getGmailSummary(userId: string): Promise<Result<GmailSumma
 
   if (!labelRes.ok || !listRes.ok) {
     const failedRes = !labelRes.ok ? labelRes : listRes;
-    if (failedRes.status === 401 || failedRes.status === 403) {
+    if (failedRes.status === 401) {
       return { ok: false, error: 'TOKEN_REFRESH_REVOKED' };
+    }
+    if (failedRes.status === 403) {
+      // 403 from Gmail API means either missing gmail scope on the token or the
+      // Gmail API is not enabled in the Google Cloud project — not a token refresh issue.
+      return { ok: false, error: 'GMAIL_API_FORBIDDEN' };
     }
     return { ok: false, error: 'TOKEN_REFRESH_NETWORK_ERROR' };
   }

--- a/backend/src/services/gmail.service.ts
+++ b/backend/src/services/gmail.service.ts
@@ -1,0 +1,130 @@
+import { eq, and } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { oauthAccounts } from '../db/schema.js';
+import { getValidAccessToken } from './token-refresh.service.js';
+import { config } from '../config.js';
+import { GOOGLE_TOKEN_URL, GMAIL_API, GMAIL_MAX_MESSAGES } from '../types/constants.js';
+import type { Result } from '../types/auth.types.js';
+import type { OAuthError } from '../types/oauth.types.js';
+
+export type GmailError = OAuthError | 'NOT_CONNECTED' | 'INSUFFICIENT_SCOPES';
+
+export interface GmailMessage {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  date: string;
+}
+
+export interface GmailSummary {
+  unreadCount: number;
+  messages: GmailMessage[];
+}
+
+interface GmailLabelResponse {
+  messagesUnread?: number;
+}
+
+interface GmailMessageListResponse {
+  messages?: Array<{ id: string }>;
+  resultSizeEstimate?: number;
+}
+
+interface GmailMessageResponse {
+  id: string;
+  snippet?: string;
+  payload?: {
+    headers?: Array<{ name: string; value: string }>;
+  };
+}
+
+const GMAIL_TTL_MS = 45_000;
+const gmailCache = new Map<string, { data: Result<GmailSummary, GmailError>; expiresAt: number }>();
+
+export function invalidateGmailCache(userId: string): void {
+  gmailCache.delete(userId);
+}
+
+export function clearGmailCacheForTest(): void {
+  gmailCache.clear();
+}
+
+function getHeader(headers: Array<{ name: string; value: string }>, name: string): string {
+  return headers.find((h) => h.name.toLowerCase() === name.toLowerCase())?.value ?? '';
+}
+
+export async function getGmailSummary(userId: string): Promise<Result<GmailSummary, GmailError>> {
+  const cached = gmailCache.get(userId);
+  if (cached && Date.now() < cached.expiresAt) return cached.data;
+
+  const [account] = await db
+    .select()
+    .from(oauthAccounts)
+    .where(and(eq(oauthAccounts.userId, userId), eq(oauthAccounts.provider, 'google')))
+    .limit(1);
+
+  if (!account) return { ok: false, error: 'NOT_CONNECTED' };
+
+  // Check that the stored token was granted with gmail.readonly scope
+  const hasGmailScope = account.scopes.some((s) => s.includes('gmail'));
+  if (!hasGmailScope) return { ok: false, error: 'INSUFFICIENT_SCOPES' };
+
+  const tokenResult = await getValidAccessToken(account, {
+    tokenUrl: GOOGLE_TOKEN_URL,
+    extraBody: { client_id: config.GOOGLE_CLIENT_ID ?? '', client_secret: config.GOOGLE_CLIENT_SECRET ?? '' },
+  });
+  if (!tokenResult.ok) return { ok: false, error: tokenResult.error };
+  const accessToken = tokenResult.data;
+
+  const headers = { Authorization: `Bearer ${accessToken}` };
+
+  // Fetch inbox unread count and top unread messages in parallel
+  const [labelRes, listRes] = await Promise.all([
+    fetch(`${GMAIL_API}/labels/INBOX`, { headers }),
+    fetch(`${GMAIL_API}/messages?q=is%3Aunread&maxResults=${GMAIL_MAX_MESSAGES}`, { headers }),
+  ]);
+
+  if (!labelRes.ok || !listRes.ok) {
+    const failedRes = !labelRes.ok ? labelRes : listRes;
+    if (failedRes.status === 401 || failedRes.status === 403) {
+      return { ok: false, error: 'TOKEN_REFRESH_REVOKED' };
+    }
+    return { ok: false, error: 'TOKEN_REFRESH_NETWORK_ERROR' };
+  }
+
+  const [labelData, listData] = await Promise.all([
+    labelRes.json() as Promise<GmailLabelResponse>,
+    listRes.json() as Promise<GmailMessageListResponse>,
+  ]);
+
+  const unreadCount = labelData.messagesUnread ?? 0;
+  const messageIds = listData.messages ?? [];
+
+  // Fetch each message's metadata in parallel
+  const messageResults = await Promise.allSettled(
+    messageIds.map(({ id }) =>
+      fetch(
+        `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=Subject&metadataHeaders=From&metadataHeaders=Date`,
+        { headers }
+      ).then((r) => r.json() as Promise<GmailMessageResponse>)
+    )
+  );
+
+  const messages: GmailMessage[] = messageResults
+    .filter((r): r is PromiseFulfilledResult<GmailMessageResponse> => r.status === 'fulfilled')
+    .map(({ value }) => {
+      const msgHeaders = value.payload?.headers ?? [];
+      return {
+        id: value.id,
+        from: getHeader(msgHeaders, 'From'),
+        subject: getHeader(msgHeaders, 'Subject') || '(No subject)',
+        snippet: value.snippet ?? '',
+        date: getHeader(msgHeaders, 'Date'),
+      };
+    });
+
+  const result: Result<GmailSummary, GmailError> = { ok: true, data: { unreadCount, messages } };
+  gmailCache.set(userId, { data: result, expiresAt: Date.now() + GMAIL_TTL_MS });
+  return result;
+}

--- a/backend/src/types/constants.ts
+++ b/backend/src/types/constants.ts
@@ -57,6 +57,16 @@ export const CALENDAR_SCOPES = [
   'profile',
 ].join(' ');
 
+export const GMAIL_SCOPES = [
+  'https://www.googleapis.com/auth/gmail.readonly',
+  'https://www.googleapis.com/auth/calendar.readonly',
+  'openid',
+  'email',
+  'profile',
+].join(' ');
+
+export const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1/users/me';
+
 // ── Business limits ───────────────────────────────────────────────────────
 
 export const MAX_CALENDAR_DAYS = 30;
@@ -64,3 +74,4 @@ export const DEFAULT_CALENDAR_DAYS = 7;
 export const MAX_CALENDAR_RESULTS = 50;
 export const MAX_TOP_TRACKS = 50;
 export const DEFAULT_TOP_TRACKS = 10;
+export const GMAIL_MAX_MESSAGES = 5;

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -510,6 +510,8 @@
       <a href="#account"><span class="l en">Account</span><span class="l he">חשבון</span></a>
       <a href="#spotify"><span class="l en">Spotify</span><span class="l he">ספוטיפיי</span></a>
       <a href="#calendar"><span class="l en">Calendar</span><span class="l he">לוח שנה</span></a>
+      <a href="#gmail"><span class="l en">Gmail</span><span class="l he">ג׳ימייל</span></a>
+      <a href="#finance"><span class="l en">Finance</span><span class="l he">פיננסים</span></a>
       <a href="#focus"><span class="l en">Focus Timer</span><span class="l he">טיימר פוקוס</span></a>
       <a href="#background"><span class="l en">Background</span><span class="l he">רקע</span></a>
       <a href="#weather"><span class="l en">Weather</span><span class="l he">מזג אוויר</span></a>
@@ -809,7 +811,7 @@
   <div class="step">
     <div class="step-num">2</div>
     <div class="step-body">
-      <p><span class="l en">In the Account tab, scroll to <strong>Connected Services</strong>. Click <strong>Connect</strong> on the Google Calendar card.</span><span class="l he">בלשונית חשבון, גלול ל<strong>שירותים מחוברים</strong>. לחץ על <strong>חבר</strong> בכרטיס Google Calendar.</span></p>
+      <p><span class="l en">Open Settings → <strong>Apps hub</strong> → click the <strong>Calendar</strong> card → click <strong>Connect</strong>.</span><span class="l he">פתח הגדרות → <strong>מרכז אפליקציות</strong> → לחץ על כרטיס <strong>לוח שנה</strong> → לחץ על <strong>חבר</strong>.</span></p>
     </div>
   </div>
 
@@ -838,6 +840,117 @@
     <strong><span class="l en">Look-ahead window</span><span class="l he">חלון מראש</span></strong> —
     <span class="l en">by default events for the next 7 days are shown. You can change this to 14 or 30 days in Settings → <strong>Calendar</strong>.</span>
     <span class="l he">כברירת מחדל מוצגים אירועים ל-7 הימים הבאים. ניתן לשנות זאת ל-14 או 30 יום בהגדרות → <strong>לוח שנה</strong>.</span>
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       GMAIL
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="gmail">
+    <span class="section-icon" style="background:rgba(234,67,53,0.12);">✉️</span>
+    <span class="l en">Connect Gmail</span><span class="l he">חיבור Gmail</span>
+  </h2>
+
+  <p>
+    <span class="l en">WindoM shows your unread Gmail count and up to 5 recent messages in the right sidebar — no need to open a new tab to check email. This requires a WindoM account and a one-time Google authorization that covers both Gmail and Calendar in a single consent.</span>
+    <span class="l he">WindoM מציג את מספר הדוא"ל שלא נקראו ועד 5 הודעות אחרונות בסרגל הצד הימני — אין צורך לפתוח לשונית חדשה כדי לבדוק דוא"ל. זה דורש חשבון WindoM ואישור Google חד-פעמי המכסה גם Gmail וגם Calendar באישור אחד.</span>
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p><span class="l en">Make sure you have a WindoM account and are signed in (Settings → Account tab).</span><span class="l he">ודא שיש לך חשבון WindoM ואתה מחובר (הגדרות → לשונית חשבון).</span></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p><span class="l en">Open Settings → <strong>Apps hub</strong> → click the <strong>Gmail</strong> card → click <strong>Connect</strong>.</span><span class="l he">פתח הגדרות → <strong>מרכז אפליקציות</strong> → לחץ על כרטיס <strong>Gmail</strong> → לחץ על <strong>חבר</strong>.</span></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <div class="l en">
+        <p>A Google authorization window opens. Choose your Google account and click <strong>Allow</strong>.</p>
+        <p>WindoM only requests read-only access to Gmail — it cannot send, edit, or delete anything.</p>
+      </div>
+      <div class="l he">
+        <p>יפתח חלון אישור של Google. בחר את חשבון Google שלך ולחץ על <strong>Allow</strong>.</p>
+        <p>WindoM מבקש גישת קריאה בלבד ל-Gmail — הוא לא יכול לשלוח, לערוך או למחוק דבר.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">4</div>
+    <div class="step-body">
+      <p><span class="l en">Done. Your unread count badge and up to 5 recent messages appear in the right sidebar. The widget refreshes every 45 seconds.</span><span class="l he">סיימת. תג הדוא"ל שלא נקרא ועד 5 הודעות אחרונות מופיעים בסרגל הצד הימני. הווידג'ט מתרענן כל 45 שניות.</span></p>
+    </div>
+  </div>
+
+  <div class="callout tip">
+    <strong><span class="l en">Show / Hide</span><span class="l he">הצג / הסתר</span></strong> —
+    <span class="l en">use the "Show Gmail in sidebar" toggle inside Settings → Apps hub → Gmail to hide the widget without disconnecting your account.</span>
+    <span class="l he">השתמש בלחצן "הצג Gmail בסרגל הצד" בתוך הגדרות → מרכז אפליקציות → Gmail כדי להסתיר את הווידג'ט מבלי לנתק את החשבון.</span>
+  </div>
+
+  <div class="callout" style="border-left-color:rgba(234,67,53,0.5);background:rgba(234,67,53,0.06);">
+    <strong><span class="l en">Gmail API access denied?</span><span class="l he">גישה ל-Gmail API נדחתה?</span></strong><br>
+    <span class="l en">The Gmail API must be enabled separately from the Calendar API in your Google Cloud project. Go to <a href="https://console.cloud.google.com" target="_blank" rel="noreferrer">console.cloud.google.com</a> → APIs &amp; Services → Library → search <strong>"Gmail API"</strong> → Enable. This is a one-time step for whoever manages the WindoM backend.</span>
+    <span class="l he">יש להפעיל את Gmail API בנפרד מ-Calendar API בפרויקט Google Cloud שלך. עבור אל <a href="https://console.cloud.google.com" target="_blank" rel="noreferrer">console.cloud.google.com</a> → APIs &amp; Services → Library → חפש <strong>"Gmail API"</strong> → הפעל.</span>
+  </div>
+
+
+  <!-- ─────────────────────────────────────────────────
+       FINANCE
+  ───────────────────────────────────────────────── -->
+
+  <h2 id="finance">
+    <span class="section-icon" style="background:rgba(74,222,128,0.10);">📈</span>
+    <span class="l en">Finance Dashboard</span><span class="l he">לוח מחוונים פיננסי</span>
+  </h2>
+
+  <p>
+    <span class="l en">Track live stock prices and crypto rates directly on your new tab. Prices update from Yahoo Finance and CoinGecko — no API key or account needed. Two scrollable cards appear on your dashboard: one for stocks, one for crypto.</span>
+    <span class="l he">עקוב אחר מחירי מניות וקריפטו בזמן אמת ישירות בלשונית החדשה שלך. המחירים מתעדכנים מ-Yahoo Finance ו-CoinGecko — אין צורך במפתח API או חשבון. שני כרטיסים גלילים מופיעים בלוח המחוונים שלך: אחד למניות ואחד לקריפטו.</span>
+  </p>
+
+  <div class="step">
+    <div class="step-num">1</div>
+    <div class="step-body">
+      <p><span class="l en">Open Settings → <strong>Apps hub</strong> → click the <strong>Finance</strong> card.</span><span class="l he">פתח הגדרות → <strong>מרכז אפליקציות</strong> → לחץ על כרטיס <strong>פיננסים</strong>.</span></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">2</div>
+    <div class="step-body">
+      <p><span class="l en">Under <strong>Stocks</strong>, type a company name or ticker in the search bar (e.g. "Apple" or "AAPL"). Select from the autocomplete results. Repeat for each ticker you want.</span><span class="l he">תחת <strong>מניות</strong>, הקלד שם חברה או טיקר בשורת החיפוש (למשל "Apple" או "AAPL"). בחר מתוצאות ההשלמה האוטומטית. חזור על כך לכל טיקר שרוצה.</span></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">3</div>
+    <div class="step-body">
+      <p><span class="l en">Under <strong>Crypto</strong>, toggle the coins you want to track (Bitcoin, Ethereum, Solana, and more).</span><span class="l he">תחת <strong>קריפטו</strong>, הפעל את המטבעות שברצונך לעקוב (Bitcoin, Ethereum, Solana ועוד).</span></p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-num">4</div>
+    <div class="step-body">
+      <p><span class="l en">The Finance dashboards appear centered on your new tab. Each card is independently scrollable and has a show/hide toggle at the top.</span><span class="l he">לוחות המחוונים הפיננסיים מופיעים במרכז לשונית החדשה שלך. כל כרטיס גלילי באופן עצמאי ויש לו לחצן הצג/הסתר בחלק העליון.</span></p>
+    </div>
+  </div>
+
+  <div class="callout tip">
+    <strong><span class="l en">Prices cached for 5 minutes</span><span class="l he">מחירים שמורים ב-cache למשך 5 דקות</span></strong> —
+    <span class="l en">adding a new ticker bypasses the cache immediately so you see the price right away.</span>
+    <span class="l he">הוספת טיקר חדש עוקפת את ה-cache מיד כך שתראה את המחיר מיידית.</span>
   </div>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1390,6 +1390,16 @@
         <p>A new inspirational quote greets you every day.</p>
       </div>
       <div class="feature-card">
+        <span class="feature-icon"><svg viewBox="0 0 24 24" fill="none" stroke="#EA4335" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg></span>
+        <h3>Gmail Inbox</h3>
+        <p>Unread count badge and your 5 most recent messages in the sidebar — no tab switching needed. Updates every 45 seconds.</p>
+      </div>
+      <div class="feature-card">
+        <span class="feature-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg></span>
+        <h3>Finance Dashboard</h3>
+        <p>Live stock prices and crypto rates. Add any ticker via autocomplete. Powered by Yahoo Finance + CoinGecko — no API key needed.</p>
+      </div>
+      <div class="feature-card">
         <span class="feature-icon"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z"/><path d="M12 13v6M9 16l3 3 3-3"/></svg></span>
         <h3>Cloud Sync <span class="feature-badge">Beta</span></h3>
         <p>Sign in once and your settings, quick links, and customizations follow you to every device automatically.</p>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "WindoM",
-  "version": "1.3.5",
+  "version": "1.4.0",
   "description": "A beautiful new tab page with background images, clock, weather, todos, and calendar",
   "permissions": [
     "storage",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "windom",
   "private": true,
-  "version": "1.3.5",
+  "version": "1.4.0",
   "type": "module",
   "engines": {
     "node": ">=22"

--- a/web/src/components/gmail/GmailWidget.tsx
+++ b/web/src/components/gmail/GmailWidget.tsx
@@ -1,0 +1,77 @@
+import { useGmail } from '../../hooks/useGmail';
+import { useSettings } from '../../contexts/SettingsContext';
+
+function GmailIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" stroke="#EA4335" strokeWidth="1.5"/>
+      <polyline points="22,6 12,13 2,6" stroke="#EA4335" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+function formatFrom(from: string): string {
+  const match = from.match(/^"?([^"<]+)"?\s*</);
+  return match ? match[1].trim() : from.split('@')[0];
+}
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return '';
+  const d = new Date(dateStr);
+  if (isNaN(d.getTime())) return '';
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate();
+  if (sameDay) return d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true });
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+export function GmailWidget() {
+  const { settings } = useSettings();
+  const { summary, loading, error } = useGmail();
+
+  if (!settings.integrations.gmail.connected || !settings.integrations.gmail.show) return null;
+
+  return (
+    <div className="gmail-widget">
+      <div className="gmail-widget-header">
+        <GmailIcon />
+        <span className="gmail-widget-title">Gmail</span>
+        {summary && summary.unreadCount > 0 && (
+          <span className="gmail-unread-badge">{summary.unreadCount > 99 ? '99+' : summary.unreadCount}</span>
+        )}
+      </div>
+
+      {loading && !summary && (
+        <div className="gmail-widget-empty">Loading…</div>
+      )}
+
+      {error && (
+        <div className="gmail-widget-error">{error}</div>
+      )}
+
+      {summary && summary.messages.length === 0 && !error && (
+        <div className="gmail-widget-empty">No unread messages</div>
+      )}
+
+      {summary && summary.messages.length > 0 && (
+        <div className="gmail-message-list">
+          {summary.messages.map((msg) => (
+            <div key={msg.id} className="gmail-message-row">
+              <div className="gmail-message-meta">
+                <span className="gmail-message-from">{formatFrom(msg.from)}</span>
+                <span className="gmail-message-date">{formatDate(msg.date)}</span>
+              </div>
+              <div className="gmail-message-subject">{msg.subject}</div>
+              {msg.snippet && (
+                <div className="gmail-message-snippet">{msg.snippet}</div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/RightSidebar.tsx
+++ b/web/src/components/layout/RightSidebar.tsx
@@ -6,6 +6,7 @@ import { TodoSection } from "../sidebar/TodoSection";
 import { CalendarSection } from "../sidebar/CalendarSection";
 import { SpotifyTopTracks } from "../spotify/SpotifyTopTracks";
 import { HistorySection } from "../sidebar/HistorySection";
+import { GmailWidget } from "../gmail/GmailWidget";
 
 export function RightSidebar() {
   const { isOpen, toggle, close } = useSidebar();
@@ -48,6 +49,7 @@ export function RightSidebar() {
           {settings.general.showTodo && <TodoSection />}
           <CalendarSection />
           {settings.integrations.spotify.connected && settings.integrations.spotify.showTopTracks && <SpotifyTopTracks />}
+          <GmailWidget />
         </div>
       </div>
     </div>

--- a/web/src/components/onboarding/GuidePanel.tsx
+++ b/web/src/components/onboarding/GuidePanel.tsx
@@ -56,14 +56,58 @@ const SECTIONS: GuideSection[] = [
         type: 'steps',
         content: [
           'Sign in or create a WindoM account (Settings → Account tab).',
-          'In the Account tab, click "Connect" on the Google Calendar card.',
-          'Authorize in the Google popup — read-only access only.',
+          'Open Settings → Apps hub → Calendar.',
+          'Click "Connect" and authorize in the Google popup — read-only access only.',
           'Your events appear in the right sidebar, grouped by day.',
         ],
       },
       {
         type: 'tip',
-        content: 'Change the look-ahead window (7 / 14 / 30 days) in Settings → Calendar.',
+        content: 'Change the look-ahead window (7 / 14 / 30 days) in Settings → Apps hub → Calendar.',
+      },
+    ],
+  },
+  {
+    id: 'gmail',
+    title: 'Connect Gmail',
+    summary: 'Shows unread count and recent messages in the sidebar. Needs a WindoM account.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Sign in or create a WindoM account (Settings → Account tab).',
+          'Open Settings → Apps hub → Gmail.',
+          'Click "Connect" and authorize in the Google popup — grants gmail.readonly and calendar.readonly together.',
+          'Your unread count badge and up to 5 recent messages appear in the right sidebar.',
+        ],
+      },
+      {
+        type: 'note',
+        content: 'Gmail access requires the Gmail API to be enabled in your Google Cloud project. If you see an "API access denied" error, go to console.cloud.google.com → APIs & Services → Library → search "Gmail API" → Enable.',
+      },
+      {
+        type: 'tip',
+        content: 'Toggle the Gmail widget on or off in Settings → Apps hub → Gmail → "Show Gmail in sidebar".',
+      },
+    ],
+  },
+  {
+    id: 'finance',
+    title: 'Finance Dashboard',
+    summary: 'Live stock and crypto prices on your dashboard — no API key needed.',
+    blocks: [
+      {
+        type: 'steps',
+        content: [
+          'Open Settings → Apps hub → Finance.',
+          'Search and add stock tickers (e.g. AAPL, TSLA, SPY) using the search bar.',
+          'Add crypto coins from the grid (Bitcoin, Ethereum, Solana, and more).',
+          'Two scrollable cards appear on your dashboard — one for stocks, one for crypto.',
+        ],
+      },
+      {
+        type: 'tip',
+        content: 'Use the show/hide toggle at the top of each card to collapse stocks or crypto independently.',
       },
     ],
   },

--- a/web/src/components/settings/sections/AppCenterPanel.tsx
+++ b/web/src/components/settings/sections/AppCenterPanel.tsx
@@ -6,11 +6,13 @@ import { SpotifySettings } from './SpotifySettings';
 import { FinanceSettings } from './FinanceSettings';
 import { TodoAppSettings } from './TodoAppSettings';
 import { HistoryAppSettings } from './HistoryAppSettings';
+import { GmailSettings } from './GmailSettings';
 
 const APP_LABELS: Record<AppId, string> = {
   calendar: 'Calendar',
   spotify: 'Spotify',
   finance: 'Finance',
+  gmail: 'Gmail',
   todo: 'Tasks',
   history: 'History',
 };
@@ -52,6 +54,15 @@ function TodoIcon() {
   );
 }
 
+function GmailPanelIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" stroke="#EA4335" strokeWidth="1.5"/>
+      <polyline points="22,6 12,13 2,6" stroke="#EA4335" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
 function HistoryIcon() {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -65,6 +76,7 @@ const APP_ICONS: Record<AppId, React.ReactNode> = {
   calendar: <CalendarIcon />,
   spotify: <SpotifyIcon />,
   finance: <FinanceIcon />,
+  gmail: <GmailPanelIcon />,
   todo: <TodoIcon />,
   history: <HistoryIcon />,
 };
@@ -115,6 +127,7 @@ export function AppCenterPanel({ appId, onClose }: AppCenterPanelProps) {
           {appId === 'calendar' && <CalendarSettings />}
           {appId === 'spotify' && <SpotifySettings />}
           {appId === 'finance' && <FinanceSettings />}
+          {appId === 'gmail' && <GmailSettings />}
           {appId === 'todo' && <TodoAppSettings />}
           {appId === 'history' && <HistoryAppSettings />}
         </div>

--- a/web/src/components/settings/sections/AppHub.tsx
+++ b/web/src/components/settings/sections/AppHub.tsx
@@ -1,6 +1,6 @@
 import { useSettings } from '../../../contexts/SettingsContext';
 
-export type AppId = 'calendar' | 'spotify' | 'finance' | 'todo' | 'history';
+export type AppId = 'calendar' | 'spotify' | 'finance' | 'gmail' | 'todo' | 'history';
 
 interface AppDef {
   id: AppId;
@@ -46,6 +46,15 @@ function TodoIcon() {
   );
 }
 
+function GmailAppIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" stroke="#EA4335" strokeWidth="1.5"/>
+      <polyline points="22,6 12,13 2,6" stroke="#EA4335" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
 function HistoryIcon() {
   return (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -73,6 +82,12 @@ const APP_DEFS: AppDef[] = [
     label: 'Finance',
     icon: <FinanceIcon />,
     connected: (s) => s.integrations.finance.connected,
+  },
+  {
+    id: 'gmail',
+    label: 'Gmail',
+    icon: <GmailAppIcon />,
+    connected: (s) => s.integrations.gmail.connected,
   },
   {
     id: 'todo',

--- a/web/src/components/settings/sections/GmailSettings.tsx
+++ b/web/src/components/settings/sections/GmailSettings.tsx
@@ -1,0 +1,179 @@
+import { useState } from 'react';
+import { useAuth } from '../../../contexts/AuthContext';
+import { useSettings } from '../../../contexts/SettingsContext';
+import { apiPost, apiFetch } from '../../../lib/api';
+import { mapOAuthError } from '../../../lib/oauth-errors';
+import { SETTINGS_EVENT } from '../../../lib/settings-events';
+
+function GmailIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" stroke="#EA4335" strokeWidth="1.5"/>
+      <polyline points="22,6 12,13 2,6" stroke="#EA4335" strokeWidth="1.5" strokeLinecap="round"/>
+    </svg>
+  );
+}
+
+function launchWebAuth(url: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      reject(new Error('Sign-in timed out. Please try again.'));
+    }, 120_000);
+    chrome.identity.launchWebAuthFlow({ url, interactive: true }, (redirectUrl) => {
+      clearTimeout(timer);
+      if (settled) return;
+      if (chrome.runtime.lastError || !redirectUrl) {
+        reject(new Error(mapOAuthError(chrome.runtime.lastError?.message ?? 'Auth cancelled')));
+      } else {
+        resolve(redirectUrl);
+      }
+    });
+  });
+}
+
+function mapIntegrationError(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/already.linked|account already linked/i.test(msg)) return 'This account is already linked to a different user.';
+  if (/network|fetch|connection|failed to fetch/i.test(msg)) return 'Connection failed. Check your internet and try again.';
+  if (msg === 'access_denied' || msg.includes('access_denied')) return mapOAuthError(msg);
+  if (msg && msg !== 'Failed') return msg;
+  return 'Something went wrong. Please try again.';
+}
+
+export function GmailSettings() {
+  const { user } = useAuth();
+  const { settings, update } = useSettings();
+  const { gmail, calendar } = settings.integrations;
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  async function connectGmail() {
+    setBusy(true);
+    setError('');
+    try {
+      const redirectUri = chrome.identity.getRedirectURL();
+      // Request expanded gmail scopes so the token covers both Calendar and Gmail
+      const { authUrl } = await apiPost<{ authUrl: string }>(
+        `/oauth/google/start?redirectUri=${encodeURIComponent(redirectUri)}&features=gmail`
+      );
+      const redirectUrl = await launchWebAuth(authUrl);
+      const params = new URL(redirectUrl).searchParams;
+      if (params.get('error')) throw new Error(mapOAuthError(params.get('error')!));
+      const code = params.get('code');
+      const state = params.get('state');
+      if (!code || !state) throw new Error('No auth code returned');
+      const { status } = await apiPost<{ status: string }>('/oauth/google/exchange', { code, state, redirectUri });
+      if (status !== 'linked') throw new Error('Linking failed');
+      // Mark both gmail and calendar as connected since we granted combined scopes
+      await update('integrations', {
+        gmail: { ...gmail, connected: true },
+        calendar: { ...calendar, connected: true },
+      });
+    } catch (err) {
+      setError(mapIntegrationError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function disconnectGmail() {
+    setBusy(true);
+    setError('');
+    try {
+      const res = await apiFetch('/integrations/google', { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to disconnect Gmail');
+      await update('integrations', {
+        gmail: { ...gmail, connected: false },
+        calendar: { ...calendar, connected: false },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Disconnect failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!user) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <div className="integration-card">
+          <div className="integration-icon" style={{ background: 'rgba(234,67,53,0.12)' }}>
+            <GmailIcon />
+          </div>
+          <div className="integration-info">
+            <div className="integration-name">Gmail</div>
+            <div className="integration-status">Not connected</div>
+          </div>
+        </div>
+        <div className="auth-required-notice">
+          <p>
+            Sign in to your WindoM account to connect Gmail.{' '}
+            <button
+              type="button"
+              className="auth-required-link"
+              onClick={() => document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.OPEN_ACCOUNT))}
+            >
+              Go to Account
+            </button>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div>
+        <div className="integration-card">
+          <div className="integration-icon" style={{ background: 'rgba(234,67,53,0.12)' }}>
+            <GmailIcon />
+          </div>
+          <div className="integration-info">
+            <div className="integration-name">Gmail</div>
+            <div className={`integration-status${gmail.connected ? ' connected' : ''}`}>
+              {gmail.connected ? 'Connected' : 'Not connected'}
+            </div>
+          </div>
+          {gmail.connected ? (
+            <button className="integration-disconnect-btn" disabled={busy} onClick={disconnectGmail}>
+              {busy ? '…' : 'Disconnect'}
+            </button>
+          ) : (
+            <button className="integration-connect-btn" disabled={busy} onClick={connectGmail}>
+              {busy ? 'Connecting…' : 'Connect'}
+            </button>
+          )}
+        </div>
+        {error && <p className="integration-error">{error}</p>}
+      </div>
+
+      {!gmail.connected && calendar.connected && (
+        <div className="auth-required-notice">
+          <p>
+            Your Google account is connected for Calendar but doesn&apos;t include Gmail access.
+            Click <strong>Connect</strong> above to grant Gmail permission (you&apos;ll see a Google consent screen).
+          </p>
+        </div>
+      )}
+
+      {gmail.connected && (
+        <div className="settings-group">
+          <label className="settings-label">Sidebar</label>
+          <label className="visibility-row" style={{ cursor: 'pointer' }}>
+            <span className="visibility-row-label">Show Gmail in sidebar</span>
+            <label className="toggle-switch">
+              <input
+                type="checkbox"
+                checked={gmail.show}
+                onChange={(e) => void update('integrations', { gmail: { ...gmail, show: e.target.checked } })}
+              />
+              <span className="toggle-track"><span className="toggle-knob" /></span>
+            </label>
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useGmail.ts
+++ b/web/src/hooks/useGmail.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { apiGet } from '../lib/api';
+import { useSettings } from '../contexts/SettingsContext';
+import { GMAIL_POLL_INTERVAL_MS } from '../lib/timing-constants';
+
+export interface GmailMessage {
+  id: string;
+  from: string;
+  subject: string;
+  snippet: string;
+  date: string;
+}
+
+export interface GmailSummary {
+  unreadCount: number;
+  messages: GmailMessage[];
+}
+
+export function useGmail() {
+  const { settings } = useSettings();
+  const gmailConnected = settings.integrations.gmail.connected;
+  const [summary, setSummary] = useState<GmailSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchSummary = useCallback(async () => {
+    try {
+      const data = await apiGet<GmailSummary>('/gmail/summary');
+      setSummary(data);
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load Gmail';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!gmailConnected) {
+      setSummary(null);
+      setError(null);
+      if (pollRef.current) clearInterval(pollRef.current);
+      return;
+    }
+
+    setLoading(true);
+    void fetchSummary();
+    pollRef.current = setInterval(() => { void fetchSummary(); }, GMAIL_POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [gmailConnected, fetchSummary]);
+
+  return { summary, loading, error, gmailConnected };
+}

--- a/web/src/hooks/useIntegrationSync.ts
+++ b/web/src/hooks/useIntegrationSync.ts
@@ -4,7 +4,7 @@ import { useSettings } from '../contexts/SettingsContext';
 import { apiGet } from '../lib/api';
 
 interface IntegrationsResponse {
-  google: { connected: boolean };
+  google: { connected: boolean; scopes: string[] };
   spotify: { connected: boolean };
 }
 
@@ -27,6 +27,7 @@ export function useIntegrationSync() {
           ...settings.integrations,
           calendar: { ...settings.integrations.calendar, connected: false },
           spotify: { ...settings.integrations.spotify, connected: false },
+          gmail: { ...settings.integrations.gmail, connected: false },
         },
       });
       return;
@@ -37,11 +38,13 @@ export function useIntegrationSync() {
     apiGet<IntegrationsResponse>('/integrations')
       .then(({ google, spotify }) => {
         if (cancelled) return;
+        const hasGmailScope = google.scopes.some((s) => s.includes('gmail'));
         void updateMultiple({
           integrations: {
             ...settings.integrations,
             calendar: { ...settings.integrations.calendar, connected: google.connected },
             spotify: { ...settings.integrations.spotify, connected: spotify.connected },
+            gmail: { ...settings.integrations.gmail, connected: google.connected && hasGmailScope },
           },
         });
       })

--- a/web/src/lib/migrateSettings.ts
+++ b/web/src/lib/migrateSettings.ts
@@ -85,6 +85,7 @@ export function migrateFlatToSectioned(legacy: LegacySettings): Settings {
         showTopTracks: d.integrations.spotify.showTopTracks,
       },
       finance: { ...d.integrations.finance },
+      gmail: { ...d.integrations.gmail },
     },
   };
 }

--- a/web/src/lib/timing-constants.ts
+++ b/web/src/lib/timing-constants.ts
@@ -27,3 +27,6 @@ export const LOADER_FADE_DURATION_MS = 600;
 
 // Calendar fetch debounce
 export const CALENDAR_FETCH_DEBOUNCE_MS = 500;
+
+// Gmail poll interval (45s matches server-side cache TTL)
+export const GMAIL_POLL_INTERVAL_MS = 45_000;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -4715,3 +4715,98 @@ body.focus-exiting .sidebar-container {
   color: #4ade80;
   flex-shrink: 0;
 }
+
+/* ── Gmail Widget ──────────────────────────────────────────────────────────── */
+
+.gmail-widget {
+  padding: 12px 0 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 8px;
+}
+.gmail-widget-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 0 2px;
+}
+.gmail-widget-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.55);
+  flex: 1;
+}
+.gmail-unread-badge {
+  background: #EA4335;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  border-radius: 10px;
+  padding: 1px 6px;
+  min-width: 18px;
+  text-align: center;
+  line-height: 1.4;
+}
+.gmail-widget-empty {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.35);
+  text-align: center;
+  padding: 8px 0 12px;
+}
+.gmail-widget-error {
+  font-size: 0.72rem;
+  color: rgba(248, 113, 113, 0.8);
+  padding: 4px 2px 8px;
+}
+.gmail-message-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.gmail-message-row {
+  padding: 7px 6px;
+  border-radius: 6px;
+  cursor: default;
+  transition: background 0.15s;
+}
+.gmail-message-row:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+.gmail-message-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 2px;
+}
+.gmail-message-from {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.gmail-message-date {
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.4);
+  flex-shrink: 0;
+}
+.gmail-message-subject {
+  font-size: 0.73rem;
+  color: rgba(255, 255, 255, 0.7);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-bottom: 2px;
+}
+.gmail-message-snippet {
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.38);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -77,10 +77,18 @@ export interface FinanceIntegration {
   connected: boolean;
 }
 
+export interface GmailIntegration {
+  /** Derived from OAuth state - excluded from backend sync. */
+  connected: boolean;
+  /** Whether to show the Gmail widget in the sidebar. */
+  show: boolean;
+}
+
 export interface IntegrationsSettings {
   calendar: CalendarIntegration;
   spotify: SpotifyIntegration;
   finance: FinanceIntegration;
+  gmail: GmailIntegration;
 }
 
 // ─── Top-level Settings ───────────────────────────────────────────────────────
@@ -196,6 +204,7 @@ export const defaultSettings: Settings = {
       showCrypto: false,
       connected: false,
     },
+    gmail: { connected: false, show: true },
   },
 };
 


### PR DESCRIPTION
## What
- Add `/gmail/summary` backend endpoint returning unread count and top 5 unread message metadata
- Add `GmailWidget` to the right sidebar showing sender, subject, snippet, and date
- Add Gmail app card to the App Hub with a settings panel for connect/disconnect + sidebar toggle

## Why
Users want a quick glance at unread Gmail directly on the new tab without opening another tab. The Calendar OAuth flow already uses a Google token — Gmail can be granted in the same consent by expanding the scope, so there's no need for a separate OAuth app or redirect URI.

## How
Extended the existing `/oauth/google/start` endpoint with a `features=gmail` query param that switches from `CALENDAR_SCOPES` to `GMAIL_SCOPES` (which includes both `gmail.readonly` and `calendar.readonly`). The backend service fetches INBOX label (unread count) and message list in parallel, then fetches per-message metadata headers in a second parallel round. A 45s in-memory cache prevents hammering the Gmail API. The extension polls the `/gmail/summary` endpoint every 45s matching the server TTL. When a user already has Calendar connected without Gmail scopes, the settings panel shows a contextual hint to reconnect.

## Test plan
- [ ] Connect Gmail via App Hub → Gmail → Connect (Google consent appears with gmail.readonly scope)
- [ ] Widget appears in sidebar with unread badge and up to 5 recent messages
- [ ] Toggle "Show Gmail in sidebar" hides/shows the widget without disconnect
- [ ] Disconnect removes widget and resets both gmail.connected and calendar.connected
- [ ] Calendar already connected → Gmail settings shows "upgrade consent" hint
- [ ] Backend: `GET /gmail/summary` returns 404 when not connected, 403 when scopes insufficient, 200 with data when connected
- [ ] Server cache: second call within 45s returns cached response

Closes #190

Generated by [Claude-Bot] of [@Yehuda Briskman]