### PR TITLE
feat: add github widget and phase 9 security fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,9 @@ jobs:
           # Minimal env required by config.ts Zod schema
           DATABASE_URL: postgresql://windom:windom@localhost:5433/windom_test
           DATABASE_URL_TEST: postgresql://windom:windom@localhost:5433/windom_test
-          JWT_ACCESS_SECRET: ci-access-secret-at-least-32-chars-long
-          REFRESH_TOKEN_SECRET: ci-refresh-secret-at-least-32-chars
-          TOKEN_ENC_KEY_BASE64: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+          JWT_ACCESS_SECRET: ${{ secrets.TEST_JWT_SECRET }}
+          REFRESH_TOKEN_SECRET: ${{ secrets.TEST_REFRESH_SECRET }}
+          TOKEN_ENC_KEY_BASE64: ${{ secrets.TEST_ENC_KEY_BASE64 }}
           NODE_ENV: test
 
   # ── Web extension ─────────────────────────────────────────────────────────

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   ci-backend:
     name: Backend - lint / typecheck / test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     services:
       postgres:
@@ -74,6 +75,7 @@ jobs:
   ci-web:
     name: Web - lint / typecheck / build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     defaults:
       run:

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -47,9 +47,9 @@ jobs:
         working-directory: backend
         env:
           DATABASE_URL: postgresql://windom:windom@localhost:5433/windom_test
-          JWT_ACCESS_SECRET: test-jwt-secret-at-least-32-chars-long
-          REFRESH_TOKEN_SECRET: test-refresh-secret-32-chars-long!!
-          TOKEN_ENC_KEY_BASE64: dGVzdC1lbmMta2V5LTMyLWJ5dGVzLWxvbmchISEhISE=
+          JWT_ACCESS_SECRET: ${{ secrets.TEST_JWT_SECRET }}
+          REFRESH_TOKEN_SECRET: ${{ secrets.TEST_REFRESH_SECRET }}
+          TOKEN_ENC_KEY_BASE64: ${{ secrets.TEST_ENC_KEY_BASE64 }}
           NODE_ENV: test
         run: npx tsx src/db/migrate.ts
 
@@ -57,9 +57,9 @@ jobs:
         working-directory: backend
         env:
           DATABASE_URL_TEST: postgresql://windom:windom@localhost:5433/windom_test
-          JWT_ACCESS_SECRET: test-jwt-secret-at-least-32-chars-long
-          REFRESH_TOKEN_SECRET: test-refresh-secret-32-chars-long!!
-          TOKEN_ENC_KEY_BASE64: dGVzdC1lbmMta2V5LTMyLWJ5dGVzLWxvbmchISEhISE=
+          JWT_ACCESS_SECRET: ${{ secrets.TEST_JWT_SECRET }}
+          REFRESH_TOKEN_SECRET: ${{ secrets.TEST_REFRESH_SECRET }}
+          TOKEN_ENC_KEY_BASE64: ${{ secrets.TEST_ENC_KEY_BASE64 }}
           NODE_ENV: test
         run: npm test
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: superfly/flyctl-actions/setup-flyctl@v1.5
+      - uses: superfly/flyctl-actions/setup-flyctl@master
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@v1.5
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/backend/drizzle/0007_simple_purifiers.sql
+++ b/backend/drizzle/0007_simple_purifiers.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "refresh_sessions" ALTER COLUMN "ip" SET DATA TYPE text;--> statement-breakpoint
+ALTER TABLE "email_tokens" ADD COLUMN "token_hash" text;--> statement-breakpoint
+ALTER TABLE "email_tokens" ADD COLUMN "token_lookup" text;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "email_tokens_lookup_idx" ON "email_tokens" USING btree ("token_lookup");

--- a/backend/drizzle/meta/0007_snapshot.json
+++ b/backend/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,587 @@
+{
+  "id": "8950b616-a810-4273-81e7-08105d813bf5",
+  "prevId": "39e5b675-54e5-426d-a40b-90978c3ed08b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.email_tokens": {
+      "name": "email_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_lookup": {
+          "name": "token_lookup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_tokens_lookup_idx": {
+          "name": "email_tokens_lookup_idx",
+          "columns": [
+            {
+              "expression": "token_lookup",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_tokens_user_id_users_id_fk": {
+          "name": "email_tokens_user_id_users_id_fk",
+          "tableFrom": "email_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "email_tokens_token_unique": {
+          "name": "email_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_accounts": {
+      "name": "oauth_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_user_id": {
+          "name": "provider_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token_enc": {
+          "name": "access_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_token_enc": {
+          "name": "refresh_token_enc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "provider_client_id": {
+          "name": "provider_client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_accounts_provider_user_idx": {
+          "name": "oauth_accounts_provider_user_idx",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_accounts_user_provider_idx": {
+          "name": "oauth_accounts_user_provider_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_accounts_user_id_users_id_fk": {
+          "name": "oauth_accounts_user_id_users_id_fk",
+          "tableFrom": "oauth_accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used": {
+          "name": "used",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_states_user_id_users_id_fk": {
+          "name": "oauth_states_user_id_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_states_state_unique": {
+          "name": "oauth_states_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_sessions": {
+      "name": "refresh_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_lookup": {
+          "name": "token_lookup",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rotated_from_id": {
+          "name": "rotated_from_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "renewal_count": {
+          "name": "renewal_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "refresh_sessions_token_lookup_idx": {
+          "name": "refresh_sessions_token_lookup_idx",
+          "columns": [
+            {
+              "expression": "token_lookup",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "refresh_sessions_rotated_from_idx": {
+          "name": "refresh_sessions_rotated_from_idx",
+          "columns": [
+            {
+              "expression": "rotated_from_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_sessions_user_id_users_id_fk": {
+          "name": "refresh_sessions_user_id_users_id_fk",
+          "tableFrom": "refresh_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776600001000,
       "tag": "0006_hash_session_ip_useragent",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1777315637392,
+      "tag": "0007_simple_purifiers",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/fly.toml
+++ b/backend/fly.toml
@@ -14,6 +14,7 @@ primary_region = "fra"
   auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 1
+  max_machines_running = 3
 
   [[http_service.checks]]
     grace_period = "10s"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -18,6 +18,7 @@ import { calendarRoutes } from './routes/calendar.js';
 import { spotifyRoutes } from './routes/spotify.js';
 import { settingsRoutes } from './routes/settings.js';
 import { gmailRoutes } from './routes/gmail.js';
+import { githubRoutes } from './routes/github.js';
 
 export interface BuildAppOptions extends FastifyServerOptions {
   /** Skip rate limiting - set to true in tests to prevent limit accumulation across test runs. */
@@ -103,6 +104,7 @@ export async function buildApp({ skipRateLimit, ...overrides }: BuildAppOptions 
   await app.register(spotifyRoutes, { prefix: '/spotify' });
   await app.register(settingsRoutes);
   await app.register(gmailRoutes, { prefix: '/gmail' });
+  await app.register(githubRoutes, { prefix: '/github' });
 
   // ── Global error handler ───────────────────────────────────────────────────
 

--- a/backend/src/controllers/github.controller.ts
+++ b/backend/src/controllers/github.controller.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import type { FastifyRequest, FastifyReply } from 'fastify';
+import * as githubService from '../services/github.service.js';
+
+const savePatBodySchema = z.object({
+  pat: z.string().min(1).max(200),
+});
+
+export async function savePatController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const parsed = savePatBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    void reply.status(400).send({ statusCode: 400, error: 'Bad Request', message: 'pat is required' });
+    return;
+  }
+
+  const result = await githubService.storePat(req.user.sub, parsed.data.pat);
+  if (!result.ok) {
+    if (result.error === 'INVALID_PAT') {
+      void reply.status(400).send({ statusCode: 400, error: 'Bad Request', message: 'Invalid PAT. Check that the token has the notifications and repo scopes.' });
+    } else {
+      void reply.status(503).send({ statusCode: 503, error: 'Service Unavailable', message: 'Could not reach GitHub. Please try again.' });
+    }
+    return;
+  }
+
+  void reply.send({ connected: true, username: result.data.username });
+}
+
+export async function getGithubSummaryController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
+  const result = await githubService.getGithubSummary(req.user.sub);
+
+  if (!result.ok) {
+    if (result.error === 'NOT_CONNECTED') {
+      void reply.status(404).send({ statusCode: 404, error: 'Not Found', message: 'GitHub not connected' });
+    } else if (result.error === 'INVALID_PAT') {
+      void reply.status(401).send({ statusCode: 401, error: 'Unauthorized', message: 'GitHub PAT is invalid or expired. Please reconnect.' });
+    } else {
+      void reply.status(503).send({ statusCode: 503, error: 'Service Unavailable', message: 'Could not reach GitHub. Please try again.' });
+    }
+    return;
+  }
+
+  reply.header('Cache-Control', 'private, max-age=60');
+  void reply.send(result.data);
+}

--- a/backend/src/controllers/integrations.controller.ts
+++ b/backend/src/controllers/integrations.controller.ts
@@ -1,8 +1,11 @@
 import { z } from 'zod';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import * as integrationsService from '../services/integrations.service.js';
+import { savePatController as saveGithubPatController } from './github.controller.js';
 
-const providerSchema = z.enum(['google', 'spotify']);
+export { saveGithubPatController };
+
+const providerSchema = z.enum(['google', 'spotify', 'github']);
 
 export async function getIntegrationsController(req: FastifyRequest, reply: FastifyReply): Promise<void> {
   const status = await integrationsService.getIntegrations(req.user.sub);

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -94,17 +94,27 @@ export const oauthStates = pgTable('oauth_states', {
 
 // ── Email Tokens (verification + password reset) ───────────────────────────
 
-export const emailTokens = pgTable('email_tokens', {
-  id: uuid('id').primaryKey().defaultRandom(),
-  userId: uuid('user_id')
-    .notNull()
-    .references(() => users.id, { onDelete: 'cascade' }),
-  token: text('token').notNull().unique(),
-  type: text('type').notNull(), // 'verify_email' | 'password_reset'
-  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
-  usedAt: timestamp('used_at', { withTimezone: true }),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
+export const emailTokens = pgTable(
+  'email_tokens',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: uuid('user_id')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    token: text('token').notNull().unique(),
+    /** bcrypt hash of raw token — for constant-time verification. */
+    tokenHash: text('token_hash'),
+    /** SHA-256 hex of raw token — for O(1) lookup (deterministic). */
+    tokenLookup: text('token_lookup'),
+    type: text('type').notNull(), // 'verify_email' | 'password_reset'
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    usedAt: timestamp('used_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('email_tokens_lookup_idx').on(table.tokenLookup),
+  ],
+);
 
 // ── User Settings ──────────────────────────────────────────────────────────
 

--- a/backend/src/routes/__tests__/e2e.test.ts
+++ b/backend/src/routes/__tests__/e2e.test.ts
@@ -30,6 +30,7 @@ import {
   userSettings,
 } from '../../db/schema.js';
 import { encryptToken } from '../../lib/crypto.js';
+import { sendVerificationEmail, sendPasswordResetEmail } from '../../lib/email.js';
 
 // Mock email transport so tests don't need a live SMTP server
 vi.mock('../../lib/email.js', () => ({
@@ -44,6 +45,7 @@ const app = await buildTestApp();
 
 beforeEach(async () => {
   await truncateAll();
+  vi.clearAllMocks();
 });
 
 afterAll(async () => {
@@ -115,6 +117,22 @@ async function waitForEmailToken(
 async function getUserByEmail(email: string) {
   const rows = await db.select().from(users).where(eq(users.email, email));
   return rows[0] ?? null;
+}
+
+/** Return the plaintext token from the last sendVerificationEmail mock call. */
+function lastSentVerifyToken(): string {
+  const calls = vi.mocked(sendVerificationEmail).mock.calls;
+  const last = calls.at(-1);
+  if (!last) throw new Error('sendVerificationEmail was not called');
+  return last[2] as string;
+}
+
+/** Return the plaintext token from the last sendPasswordResetEmail mock call. */
+function lastSentResetToken(): string {
+  const calls = vi.mocked(sendPasswordResetEmail).mock.calls;
+  const last = calls.at(-1);
+  if (!last) throw new Error('sendPasswordResetEmail was not called');
+  return last[2] as string;
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -223,7 +241,7 @@ describe('Journey 2 - email verification', () => {
     // Click the verification link
     const verifyRes = await app.inject({
       method: 'GET',
-      url: `/auth/verify-email?token=${emailToken!.token}`,
+      url: `/auth/verify-email?token=${lastSentVerifyToken()}`,
     });
     expect(verifyRes.statusCode).toBe(200);
     expect(verifyRes.headers['content-type']).toContain('text/html');
@@ -252,7 +270,7 @@ describe('Journey 2 - email verification', () => {
       .where(eq(emailTokens.id, emailToken!.id));
 
     const res = await app.inject({
-      method: 'GET', url: `/auth/verify-email?token=${emailToken!.token}`,
+      method: 'GET', url: `/auth/verify-email?token=${lastSentVerifyToken()}`,
     });
     expect(res.statusCode).toBe(200);
     expect(res.body).toContain('invalid');
@@ -261,12 +279,13 @@ describe('Journey 2 - email verification', () => {
   it('already-used token is rejected', async () => {
     await fullRegister();
     const user = await getUserByEmail('user@e2e.test');
-    const emailToken = await waitForEmailToken(user.id, 'verify_email');
+    await waitForEmailToken(user.id, 'verify_email');
+    const verifyToken = lastSentVerifyToken();
 
     // Use it once
-    await app.inject({ method: 'GET', url: `/auth/verify-email?token=${emailToken!.token}` });
+    await app.inject({ method: 'GET', url: `/auth/verify-email?token=${verifyToken}` });
     // Use it again
-    const res = await app.inject({ method: 'GET', url: `/auth/verify-email?token=${emailToken!.token}` });
+    const res = await app.inject({ method: 'GET', url: `/auth/verify-email?token=${verifyToken}` });
     expect(res.body).toContain('invalid');
   });
 
@@ -297,7 +316,7 @@ describe('Journey 2 - email verification', () => {
     const emailToken = await waitForEmailToken(user.id, 'verify_email');
 
     // Verify first
-    await app.inject({ method: 'GET', url: `/auth/verify-email?token=${emailToken!.token}` });
+    await app.inject({ method: 'GET', url: `/auth/verify-email?token=${lastSentVerifyToken()}` });
 
     // Re-login to get a token with emailVerified=true
     const newToken = (await login()).json<{ accessToken: string }>().accessToken;
@@ -334,7 +353,7 @@ describe('Journey 3 - password reset', () => {
 
     // GET reset page renders HTML form
     const pageRes = await app.inject({
-      method: 'GET', url: `/auth/reset-password?token=${resetToken!.token}`,
+      method: 'GET', url: `/auth/reset-password?token=${lastSentResetToken()}`,
     });
     expect(pageRes.statusCode).toBe(200);
     expect(pageRes.headers['content-type']).toContain('text/html');
@@ -345,7 +364,7 @@ describe('Journey 3 - password reset', () => {
     const resetRes = await app.inject({
       method: 'POST', url: '/auth/reset-password',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: `token=${resetToken!.token}&newPassword=${newPassword}`,
+      payload: `token=${lastSentResetToken()}&newPassword=${newPassword}`,
     });
     expect(resetRes.statusCode).toBe(200);
     expect(resetRes.body).toContain('updated');
@@ -379,19 +398,20 @@ describe('Journey 3 - password reset', () => {
     await register();
     const user = await getUserByEmail('user@e2e.test');
     await app.inject({ method: 'POST', url: '/auth/forgot-password', payload: { email: 'user@e2e.test' } });
-    const resetToken = await getLatestEmailToken(user.id, 'password_reset');
+    await getLatestEmailToken(user.id, 'password_reset');
+    const resetTokenValue = lastSentResetToken();
 
     await app.inject({
       method: 'POST', url: '/auth/reset-password',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: `token=${resetToken!.token}&newPassword=FirstReset123!`,
+      payload: `token=${resetTokenValue}&newPassword=FirstReset123!`,
     });
 
     // Replay
     const replayRes = await app.inject({
       method: 'POST', url: '/auth/reset-password',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: `token=${resetToken!.token}&newPassword=HackAttempt999!`,
+      payload: `token=${resetTokenValue}&newPassword=HackAttempt999!`,
     });
     expect(replayRes.body).toContain('invalid');
 
@@ -405,6 +425,7 @@ describe('Journey 3 - password reset', () => {
     const user = await getUserByEmail('user@e2e.test');
     await app.inject({ method: 'POST', url: '/auth/forgot-password', payload: { email: 'user@e2e.test' } });
     const resetToken = await getLatestEmailToken(user.id, 'password_reset');
+    const resetTokenValue = lastSentResetToken();
 
     await db.update(emailTokens)
       .set({ expiresAt: new Date(Date.now() - 1000) })
@@ -413,7 +434,7 @@ describe('Journey 3 - password reset', () => {
     const res = await app.inject({
       method: 'POST', url: '/auth/reset-password',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: `token=${resetToken!.token}&newPassword=ShouldNotWork1!`,
+      payload: `token=${resetTokenValue}&newPassword=ShouldNotWork1!`,
     });
     expect(res.body).toContain('invalid');
   });
@@ -426,11 +447,11 @@ describe('Journey 3 - password reset', () => {
     const user = await getUserByEmail('user@e2e.test');
 
     await app.inject({ method: 'POST', url: '/auth/forgot-password', payload: { email: 'user@e2e.test' } });
-    const resetToken = await getLatestEmailToken(user.id, 'password_reset');
+    await getLatestEmailToken(user.id, 'password_reset');
     await app.inject({
       method: 'POST', url: '/auth/reset-password',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      payload: `token=${resetToken!.token}&newPassword=AfterReset123!`,
+      payload: `token=${lastSentResetToken()}&newPassword=AfterReset123!`,
     });
 
     // Both old sessions should now be invalid

--- a/backend/src/routes/__tests__/e2e.test.ts
+++ b/backend/src/routes/__tests__/e2e.test.ts
@@ -124,7 +124,7 @@ function lastSentVerifyToken(): string {
   const calls = vi.mocked(sendVerificationEmail).mock.calls;
   const last = calls.at(-1);
   if (!last) throw new Error('sendVerificationEmail was not called');
-  return last[2] as string;
+  return last[2];
 }
 
 /** Return the plaintext token from the last sendPasswordResetEmail mock call. */
@@ -132,7 +132,7 @@ function lastSentResetToken(): string {
   const calls = vi.mocked(sendPasswordResetEmail).mock.calls;
   const last = calls.at(-1);
   if (!last) throw new Error('sendPasswordResetEmail was not called');
-  return last[2] as string;
+  return last[2];
 }
 
 // ══════════════════════════════════════════════════════════════════════════
@@ -313,7 +313,7 @@ describe('Journey 2 - email verification', () => {
   it('resend returns 400 if email already verified', async () => {
     await fullRegister();
     const user = await getUserByEmail('user@e2e.test');
-    const emailToken = await waitForEmailToken(user.id, 'verify_email');
+    await waitForEmailToken(user.id, 'verify_email');
 
     // Verify first
     await app.inject({ method: 'GET', url: `/auth/verify-email?token=${lastSentVerifyToken()}` });

--- a/backend/src/routes/github.ts
+++ b/backend/src/routes/github.ts
@@ -1,0 +1,31 @@
+import type { FastifyInstance } from 'fastify';
+import { authenticate } from '../middleware/authenticate.js';
+import { getGithubSummaryController } from '../controllers/github.controller.js';
+
+const security = [{ bearerAuth: [] }];
+const errorResponse = { $ref: 'Error#' };
+
+export function githubRoutes(app: FastifyInstance): void {
+  app.get('/summary', {
+    preHandler: authenticate,
+    schema: {
+      tags: ['GitHub'],
+      summary: 'Get GitHub notification and PR summary',
+      security,
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            notificationCount: { type: 'integer' },
+            reviewRequested: { type: 'integer' },
+            assignedIssues: { type: 'integer' },
+            username: { type: 'string' },
+          },
+        },
+        401: errorResponse,
+        404: errorResponse,
+        503: errorResponse,
+      },
+    },
+  }, getGithubSummaryController);
+}

--- a/backend/src/routes/integrations.ts
+++ b/backend/src/routes/integrations.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { authenticate } from '../middleware/authenticate.js';
-import { getIntegrationsController, deleteIntegrationController } from '../controllers/integrations.controller.js';
+import { getIntegrationsController, deleteIntegrationController, saveGithubPatController } from '../controllers/integrations.controller.js';
 
 const security = [{ bearerAuth: [] }];
 const errorResponse = { $ref: 'Error#' };
@@ -10,7 +10,7 @@ export function integrationsRoutes(app: FastifyInstance): void {
     preHandler: authenticate,
     schema: {
       tags: ['Integrations'],
-      summary: 'Get integration status for google and spotify',
+      summary: 'Get integration status for google, spotify, and github',
       security,
       response: {
         200: {
@@ -30,6 +30,12 @@ export function integrationsRoutes(app: FastifyInstance): void {
                 scopes: { type: 'array', items: { type: 'string' } },
               },
             },
+            github: {
+              type: 'object',
+              properties: {
+                connected: { type: 'boolean' },
+              },
+            },
           },
         },
         401: errorResponse,
@@ -37,11 +43,39 @@ export function integrationsRoutes(app: FastifyInstance): void {
     },
   }, getIntegrationsController);
 
+  app.post('/github/pat', {
+    preHandler: authenticate,
+    schema: {
+      tags: ['Integrations'],
+      summary: 'Store an encrypted GitHub Personal Access Token',
+      security,
+      body: {
+        type: 'object',
+        required: ['pat'],
+        properties: {
+          pat: { type: 'string', minLength: 1, maxLength: 200 },
+        },
+      },
+      response: {
+        200: {
+          type: 'object',
+          properties: {
+            connected: { type: 'boolean' },
+            username: { type: 'string' },
+          },
+        },
+        400: errorResponse,
+        401: errorResponse,
+        503: errorResponse,
+      },
+    },
+  }, saveGithubPatController);
+
   app.delete('/:provider', {
     preHandler: authenticate,
     schema: {
       tags: ['Integrations'],
-      summary: 'Unlink an OAuth integration - :provider is google or spotify',
+      summary: 'Unlink an integration - :provider is google, spotify, or github',
       security,
       response: {
         200: { type: 'object', properties: { success: { type: 'boolean' } } },

--- a/backend/src/services/__tests__/integrations.service.test.ts
+++ b/backend/src/services/__tests__/integrations.service.test.ts
@@ -20,6 +20,7 @@ describe('getIntegrations', () => {
 
     const result = await getIntegrations('user-1');
     expect(result).toEqual({
+      github: { connected: false },
       google: { connected: false, scopes: [] },
       spotify: { connected: false, scopes: [] },
     });

--- a/backend/src/services/auth-email.service.ts
+++ b/backend/src/services/auth-email.service.ts
@@ -1,5 +1,7 @@
-import { randomBytes } from 'crypto';
+import { randomBytes, createHash } from 'crypto';
 import { eq, and, isNull, gt } from 'drizzle-orm';
+import bcrypt from 'bcryptjs';
+import { BCRYPT_ROUNDS } from '../types/constants.js';
 import { db } from '../db/client.js';
 import { users, emailTokens } from '../db/schema.js';
 import { hashPassword } from '../lib/password.js';
@@ -12,6 +14,10 @@ import {
 
 type TokenType = 'verify_email' | 'password_reset';
 
+function sha256hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
 async function createToken(userId: string, type: TokenType, ttlMs: number): Promise<string> {
   // Delete any prior unused token of the same type for this user
   await db
@@ -19,9 +25,14 @@ async function createToken(userId: string, type: TokenType, ttlMs: number): Prom
     .where(and(eq(emailTokens.userId, userId), eq(emailTokens.type, type), isNull(emailTokens.usedAt)));
 
   const token = randomBytes(32).toString('hex');
+  const tokenLookup = sha256hex(token);
+  const tokenHash = await bcrypt.hash(token, BCRYPT_ROUNDS);
+
   await db.insert(emailTokens).values({
     userId,
-    token,
+    token: tokenHash,   // store bcrypt hash, not plaintext
+    tokenHash,
+    tokenLookup,
     type,
     expiresAt: new Date(Date.now() + ttlMs),
   });
@@ -29,12 +40,13 @@ async function createToken(userId: string, type: TokenType, ttlMs: number): Prom
 }
 
 async function consumeToken(token: string, type: TokenType): Promise<string | null> {
+  const lookup = sha256hex(token);
   const [row] = await db
     .select()
     .from(emailTokens)
     .where(
       and(
-        eq(emailTokens.token, token),
+        eq(emailTokens.tokenLookup, lookup),
         eq(emailTokens.type, type),
         isNull(emailTokens.usedAt),
         gt(emailTokens.expiresAt, new Date()),
@@ -42,6 +54,8 @@ async function consumeToken(token: string, type: TokenType): Promise<string | nu
     )
     .limit(1);
   if (!row) return null;
+  // Verify via bcrypt (row.tokenHash is set for new rows; old rows with null fail here)
+  if (!row.tokenHash || !(await bcrypt.compare(token, row.tokenHash))) return null;
   await db.update(emailTokens).set({ usedAt: new Date() }).where(eq(emailTokens.id, row.id));
   return row.userId;
 }

--- a/backend/src/services/github.service.ts
+++ b/backend/src/services/github.service.ts
@@ -1,0 +1,121 @@
+import { eq, and } from 'drizzle-orm';
+import { db } from '../db/client.js';
+import { oauthAccounts } from '../db/schema.js';
+import { encrypt, decrypt } from '../lib/crypto.js';
+import { GITHUB_API } from '../types/constants.js';
+import type { Result } from '../types/auth.types.js';
+
+export type GitHubError = 'NOT_CONNECTED' | 'INVALID_PAT' | 'GITHUB_API_ERROR';
+
+export interface GitHubSummary {
+  notificationCount: number;
+  reviewRequested: number;
+  assignedIssues: number;
+  username: string;
+}
+
+interface GitHubUser {
+  login: string;
+}
+
+interface GitHubSearchResult {
+  total_count: number;
+}
+
+const GITHUB_TTL_MS = 60_000;
+const githubCache = new Map<string, { data: Result<GitHubSummary, GitHubError>; expiresAt: number }>();
+
+export function invalidateGithubCache(userId: string): void {
+  githubCache.delete(userId);
+}
+
+export function clearGithubCacheForTest(): void {
+  githubCache.clear();
+}
+
+export async function storePat(userId: string, rawPat: string): Promise<Result<{ username: string }, GitHubError>> {
+  // Verify PAT and get GitHub username
+  const userRes = await fetch(`${GITHUB_API}/user`, {
+    headers: {
+      Authorization: `token ${rawPat}`,
+      Accept: 'application/vnd.github+json',
+    },
+  });
+
+  if (userRes.status === 401 || userRes.status === 403) {
+    return { ok: false, error: 'INVALID_PAT' };
+  }
+  if (!userRes.ok) {
+    return { ok: false, error: 'GITHUB_API_ERROR' };
+  }
+
+  const userData = (await userRes.json()) as GitHubUser;
+  const username = userData.login;
+
+  const accessTokenEnc = await encrypt(rawPat);
+
+  // Upsert: delete existing then insert (avoids unique constraint issues)
+  await db
+    .delete(oauthAccounts)
+    .where(and(eq(oauthAccounts.userId, userId), eq(oauthAccounts.provider, 'github')));
+
+  await db.insert(oauthAccounts).values({
+    userId,
+    provider: 'github',
+    providerUserId: username,
+    accessTokenEnc,
+    scopes: ['notifications', 'repo'],
+  });
+
+  invalidateGithubCache(userId);
+  return { ok: true, data: { username } };
+}
+
+export async function getGithubSummary(userId: string): Promise<Result<GitHubSummary, GitHubError>> {
+  const cached = githubCache.get(userId);
+  if (cached && Date.now() < cached.expiresAt) return cached.data;
+
+  const [account] = await db
+    .select()
+    .from(oauthAccounts)
+    .where(and(eq(oauthAccounts.userId, userId), eq(oauthAccounts.provider, 'github')))
+    .limit(1);
+
+  if (!account) return { ok: false, error: 'NOT_CONNECTED' };
+
+  const rawPat = await decrypt(account.accessTokenEnc);
+
+  const headers = {
+    Authorization: `token ${rawPat}`,
+    Accept: 'application/vnd.github+json',
+  };
+
+  const [notifRes, reviewRes, issueRes] = await Promise.all([
+    fetch(`${GITHUB_API}/notifications?all=false&per_page=50`, { headers }),
+    fetch(`${GITHUB_API}/search/issues?q=type:pr+review-requested:@me+state:open&per_page=1`, { headers }),
+    fetch(`${GITHUB_API}/search/issues?q=assignee:@me+state:open+type:issue&per_page=1`, { headers }),
+  ]);
+
+  if (!notifRes.ok || !reviewRes.ok || !issueRes.ok) {
+    const failed = [notifRes, reviewRes, issueRes].find((r) => !r.ok);
+    if (failed?.status === 401) return { ok: false, error: 'INVALID_PAT' };
+    return { ok: false, error: 'GITHUB_API_ERROR' };
+  }
+
+  const [notifData, reviewData, issueData] = await Promise.all([
+    notifRes.json() as Promise<unknown[]>,
+    reviewRes.json() as Promise<GitHubSearchResult>,
+    issueRes.json() as Promise<GitHubSearchResult>,
+  ]);
+
+  const summary: GitHubSummary = {
+    notificationCount: Array.isArray(notifData) ? notifData.length : 0,
+    reviewRequested: reviewData.total_count ?? 0,
+    assignedIssues: issueData.total_count ?? 0,
+    username: account.providerUserId,
+  };
+
+  const result: Result<GitHubSummary, GitHubError> = { ok: true, data: summary };
+  githubCache.set(userId, { data: result, expiresAt: Date.now() + GITHUB_TTL_MS });
+  return result;
+}

--- a/backend/src/services/github.service.ts
+++ b/backend/src/services/github.service.ts
@@ -1,7 +1,7 @@
 import { eq, and } from 'drizzle-orm';
 import { db } from '../db/client.js';
 import { oauthAccounts } from '../db/schema.js';
-import { encrypt, decrypt } from '../lib/crypto.js';
+import { encryptToken, decryptToken } from '../lib/crypto.js';
 import { GITHUB_API } from '../types/constants.js';
 import type { Result } from '../types/auth.types.js';
 
@@ -52,7 +52,7 @@ export async function storePat(userId: string, rawPat: string): Promise<Result<{
   const userData = (await userRes.json()) as GitHubUser;
   const username = userData.login;
 
-  const accessTokenEnc = await encrypt(rawPat);
+  const accessTokenEnc = await encryptToken(rawPat);
 
   // Upsert: delete existing then insert (avoids unique constraint issues)
   await db
@@ -83,7 +83,7 @@ export async function getGithubSummary(userId: string): Promise<Result<GitHubSum
 
   if (!account) return { ok: false, error: 'NOT_CONNECTED' };
 
-  const rawPat = await decrypt(account.accessTokenEnc);
+  const rawPat = await decryptToken(account.accessTokenEnc);
 
   const headers = {
     Authorization: `token ${rawPat}`,

--- a/backend/src/services/integrations.service.ts
+++ b/backend/src/services/integrations.service.ts
@@ -4,10 +4,12 @@ import { oauthAccounts } from '../db/schema.js';
 import type { OAuthProvider } from '../types/oauth.types.js';
 import { invalidateCalendarCache } from './calendar.service.js';
 import { invalidateNowPlayingCache } from './spotify.service.js';
+import { invalidateGithubCache } from './github.service.js';
 
 export interface IntegrationsStatus {
   google: { connected: boolean; scopes: string[] };
   spotify: { connected: boolean; scopes: string[] };
+  github: { connected: boolean };
 }
 
 export async function getIntegrations(userId: string): Promise<IntegrationsStatus> {
@@ -18,10 +20,12 @@ export async function getIntegrations(userId: string): Promise<IntegrationsStatu
 
   const google = accounts.find((a) => a.provider === 'google');
   const spotify = accounts.find((a) => a.provider === 'spotify');
+  const github = accounts.find((a) => a.provider === 'github');
 
   return {
     google: { connected: !!google, scopes: google?.scopes ?? [] },
     spotify: { connected: !!spotify, scopes: spotify?.scopes ?? [] },
+    github: { connected: !!github },
   };
 }
 
@@ -34,5 +38,7 @@ export async function unlinkProvider(userId: string, provider: OAuthProvider): P
     invalidateCalendarCache(userId);
   } else if (provider === 'spotify') {
     invalidateNowPlayingCache(userId);
+  } else if (provider === 'github') {
+    invalidateGithubCache(userId);
   }
 }

--- a/backend/src/types/constants.ts
+++ b/backend/src/types/constants.ts
@@ -75,3 +75,5 @@ export const MAX_CALENDAR_RESULTS = 50;
 export const MAX_TOP_TRACKS = 50;
 export const DEFAULT_TOP_TRACKS = 10;
 export const GMAIL_MAX_MESSAGES = 5;
+
+export const GITHUB_API = 'https://api.github.com';

--- a/backend/src/types/oauth.types.ts
+++ b/backend/src/types/oauth.types.ts
@@ -1,4 +1,4 @@
-export type OAuthProvider = 'google' | 'spotify';
+export type OAuthProvider = 'google' | 'spotify' | 'github';
 
 export type OAuthPurpose = 'login' | 'link';
 

--- a/web/CLAUDE.md
+++ b/web/CLAUDE.md
@@ -85,3 +85,9 @@ web/                               (repo root for the extension)
 ## Publishing
 
 The `.github/workflows/publish-chrome.yml` workflow auto-publishes to Chrome Web Store when a git tag matching `v*` is pushed. Required secrets: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`.
+
+## Content Script Match Scope (Issue #203 — Resolved as By Design)
+
+The content script declared in `manifest.json` uses `"matches": ["http://*/*", "https://*/*"]`. This is the minimum required scope and cannot be narrowed without breaking the core feature.
+
+The content script renders a full-page shadow DOM overlay (the tab sidebar) that must be present on every web page the user visits. There is no URL pattern more restrictive than `<all_urls>` that would preserve this behavior. Issue #203 is resolved as "by design" — the broad match is a functional requirement, not an oversight.

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -22,7 +22,8 @@
     "https://api.windom.app/*",
     "https://query1.finance.yahoo.com/*",
     "https://query2.finance.yahoo.com/*",
-    "https://api.coingecko.com/*"
+    "https://api.coingecko.com/*",
+    "https://api.github.com/*"
   ],
   "background": {
     "service_worker": "src/background/index.ts",

--- a/web/src/background/index.ts
+++ b/web/src/background/index.ts
@@ -40,8 +40,19 @@ type CmdMessage =
   | { type: 'WINDOM_CMD_PIN_TAB' }
   | { type: 'WINDOM_CMD_OPEN_URL'; url: string };
 
+const VALID_CMD_TYPES = new Set<string>([
+  'WINDOM_CMD_NEW_TAB',
+  'WINDOM_CMD_CLOSE_TAB',
+  'WINDOM_CMD_DUPLICATE_TAB',
+  'WINDOM_CMD_PIN_TAB',
+  'WINDOM_CMD_OPEN_URL',
+]);
+
 chrome.runtime.onMessage.addListener(
   (message: CmdMessage, sender, sendResponse) => {
+    if (sender.id !== chrome.runtime.id) return;
+    if (!VALID_CMD_TYPES.has(message.type)) return;
+
     const tabId = sender.tab?.id;
 
     const handle = async () => {

--- a/web/src/components/github/GitHubWidget.tsx
+++ b/web/src/components/github/GitHubWidget.tsx
@@ -1,0 +1,106 @@
+import { useGitHub } from '../../hooks/useGitHub';
+import { useSettings } from '../../contexts/SettingsContext';
+
+function GitHubIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
+function BellIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+      <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+    </svg>
+  );
+}
+
+function PRIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="18" cy="18" r="3" />
+      <circle cx="6" cy="6" r="3" />
+      <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+      <line x1="6" y1="9" x2="6" y2="21" />
+    </svg>
+  );
+}
+
+function IssueIcon() {
+  return (
+    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+export function GitHubWidget() {
+  const { settings } = useSettings();
+  const { summary, loading, error } = useGitHub();
+
+  if (!settings.integrations.github.connected || !settings.integrations.github.show) return null;
+
+  const rows = summary ? [
+    {
+      icon: <BellIcon />,
+      label: 'Notifications',
+      count: summary.notificationCount,
+      href: 'https://github.com/notifications',
+    },
+    {
+      icon: <PRIcon />,
+      label: 'Review Requests',
+      count: summary.reviewRequested,
+      href: 'https://github.com/pulls/review-requested',
+    },
+    {
+      icon: <IssueIcon />,
+      label: 'Assigned Issues',
+      count: summary.assignedIssues,
+      href: 'https://github.com/issues/assigned',
+    },
+  ] : [];
+
+  return (
+    <div className="github-widget">
+      <div className="github-widget-header">
+        <GitHubIcon />
+        <span className="github-widget-title">GitHub</span>
+        {summary && summary.notificationCount > 0 && (
+          <span className="github-badge">{summary.notificationCount > 99 ? '99+' : summary.notificationCount}</span>
+        )}
+      </div>
+
+      {loading && !summary && (
+        <div className="github-widget-empty">Loading…</div>
+      )}
+
+      {error && (
+        <div className="github-widget-error">{error}</div>
+      )}
+
+      {summary && (
+        <div className="github-stat-list">
+          {rows.map((row) => (
+            <a
+              key={row.label}
+              href={row.href}
+              target="_blank"
+              rel="noreferrer"
+              className="github-stat-row"
+            >
+              <span className="github-stat-icon">{row.icon}</span>
+              <span className="github-stat-label">{row.label}</span>
+              <span className="github-stat-count">{row.count}</span>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/layout/RightSidebar.tsx
+++ b/web/src/components/layout/RightSidebar.tsx
@@ -7,6 +7,7 @@ import { CalendarSection } from "../sidebar/CalendarSection";
 import { SpotifyTopTracks } from "../spotify/SpotifyTopTracks";
 import { HistorySection } from "../sidebar/HistorySection";
 import { GmailWidget } from "../gmail/GmailWidget";
+import { GitHubWidget } from "../github/GitHubWidget";
 
 export function RightSidebar() {
   const { isOpen, toggle, close } = useSidebar();
@@ -50,6 +51,7 @@ export function RightSidebar() {
           <CalendarSection />
           {settings.integrations.spotify.connected && settings.integrations.spotify.showTopTracks && <SpotifyTopTracks />}
           <GmailWidget />
+          <GitHubWidget />
         </div>
       </div>
     </div>

--- a/web/src/components/settings/sections/AppCenterPanel.tsx
+++ b/web/src/components/settings/sections/AppCenterPanel.tsx
@@ -7,12 +7,14 @@ import { FinanceSettings } from './FinanceSettings';
 import { TodoAppSettings } from './TodoAppSettings';
 import { HistoryAppSettings } from './HistoryAppSettings';
 import { GmailSettings } from './GmailSettings';
+import { GitHubSettings } from './GitHubSettings';
 
 const APP_LABELS: Record<AppId, string> = {
   calendar: 'Calendar',
   spotify: 'Spotify',
   finance: 'Finance',
   gmail: 'Gmail',
+  github: 'GitHub',
   todo: 'Tasks',
   history: 'History',
 };
@@ -63,6 +65,14 @@ function GmailPanelIcon() {
   );
 }
 
+function GitHubPanelIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
 function HistoryIcon() {
   return (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -77,6 +87,7 @@ const APP_ICONS: Record<AppId, React.ReactNode> = {
   spotify: <SpotifyIcon />,
   finance: <FinanceIcon />,
   gmail: <GmailPanelIcon />,
+  github: <GitHubPanelIcon />,
   todo: <TodoIcon />,
   history: <HistoryIcon />,
 };
@@ -128,6 +139,7 @@ export function AppCenterPanel({ appId, onClose }: AppCenterPanelProps) {
           {appId === 'spotify' && <SpotifySettings />}
           {appId === 'finance' && <FinanceSettings />}
           {appId === 'gmail' && <GmailSettings />}
+          {appId === 'github' && <GitHubSettings />}
           {appId === 'todo' && <TodoAppSettings />}
           {appId === 'history' && <HistoryAppSettings />}
         </div>

--- a/web/src/components/settings/sections/AppHub.tsx
+++ b/web/src/components/settings/sections/AppHub.tsx
@@ -1,6 +1,6 @@
 import { useSettings } from '../../../contexts/SettingsContext';
 
-export type AppId = 'calendar' | 'spotify' | 'finance' | 'gmail' | 'todo' | 'history';
+export type AppId = 'calendar' | 'spotify' | 'finance' | 'gmail' | 'github' | 'todo' | 'history';
 
 interface AppDef {
   id: AppId;
@@ -55,6 +55,14 @@ function GmailAppIcon() {
   );
 }
 
+function GitHubAppIcon() {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
 function HistoryIcon() {
   return (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -88,6 +96,12 @@ const APP_DEFS: AppDef[] = [
     label: 'Gmail',
     icon: <GmailAppIcon />,
     connected: (s) => s.integrations.gmail.connected,
+  },
+  {
+    id: 'github',
+    label: 'GitHub',
+    icon: <GitHubAppIcon />,
+    connected: (s) => s.integrations.github.connected,
   },
   {
     id: 'todo',

--- a/web/src/components/settings/sections/GitHubSettings.tsx
+++ b/web/src/components/settings/sections/GitHubSettings.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+import { useAuth } from '../../../contexts/AuthContext';
+import { useSettings } from '../../../contexts/SettingsContext';
+import { apiPost, apiFetch } from '../../../lib/api';
+import { SETTINGS_EVENT } from '../../../lib/settings-events';
+
+function GitHubIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}
+
+export function GitHubSettings() {
+  const { user } = useAuth();
+  const { settings, update } = useSettings();
+  const { github } = settings.integrations;
+  const [busy, setBusy] = useState(false);
+  const [pat, setPat] = useState('');
+  const [error, setError] = useState('');
+
+  async function connectGitHub() {
+    if (!pat.trim()) {
+      setError('Please enter a Personal Access Token.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      await apiPost('/integrations/github/pat', { pat: pat.trim() });
+      setPat('');
+      await update('integrations', { github: { ...github, connected: true } });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Connection failed';
+      if (/invalid pat|invalid.*token|401/i.test(msg)) {
+        setError('Invalid token. Make sure the PAT has the notifications and repo scopes.');
+      } else if (/network|fetch|connection/i.test(msg)) {
+        setError('Connection failed. Check your internet and try again.');
+      } else {
+        setError(msg || 'Something went wrong. Please try again.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function disconnectGitHub() {
+    setBusy(true);
+    setError('');
+    try {
+      const res = await apiFetch('/integrations/github', { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to disconnect GitHub');
+      await update('integrations', { github: { ...github, connected: false } });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Disconnect failed');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!user) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+        <div className="integration-card">
+          <div className="integration-icon" style={{ background: 'rgba(255,255,255,0.08)' }}>
+            <GitHubIcon />
+          </div>
+          <div className="integration-info">
+            <div className="integration-name">GitHub</div>
+            <div className="integration-status">Not connected</div>
+          </div>
+        </div>
+        <div className="auth-required-notice">
+          <p>
+            Sign in to your WindoM account to connect GitHub.{' '}
+            <button
+              type="button"
+              className="auth-required-link"
+              onClick={() => document.dispatchEvent(new CustomEvent(SETTINGS_EVENT.OPEN_ACCOUNT))}
+            >
+              Go to Account
+            </button>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+      <div>
+        <div className="integration-card">
+          <div className="integration-icon" style={{ background: 'rgba(255,255,255,0.08)' }}>
+            <GitHubIcon />
+          </div>
+          <div className="integration-info">
+            <div className="integration-name">GitHub</div>
+            <div className={`integration-status${github.connected ? ' connected' : ''}`}>
+              {github.connected ? 'Connected' : 'Not connected'}
+            </div>
+          </div>
+          {github.connected && (
+            <button className="integration-disconnect-btn" disabled={busy} onClick={disconnectGitHub}>
+              {busy ? '…' : 'Disconnect'}
+            </button>
+          )}
+        </div>
+        {error && <p className="integration-error">{error}</p>}
+      </div>
+
+      {!github.connected && (
+        <div className="settings-group">
+          <label className="settings-label">Personal Access Token</label>
+          <p className="settings-hint" style={{ marginBottom: '8px' }}>
+            Create a{' '}
+            <a
+              href="https://github.com/settings/tokens/new?scopes=notifications,repo&description=WindoM"
+              target="_blank"
+              rel="noreferrer"
+              className="auth-required-link"
+            >
+              Classic PAT
+            </a>{' '}
+            with <code>notifications</code> and <code>repo</code> scopes.
+          </p>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <input
+              type="password"
+              className="settings-input"
+              placeholder="ghp_..."
+              value={pat}
+              onChange={(e) => setPat(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void connectGitHub(); }}
+              disabled={busy}
+              style={{ flex: 1 }}
+            />
+            <button className="integration-connect-btn" disabled={busy || !pat.trim()} onClick={() => void connectGitHub()}>
+              {busy ? 'Connecting…' : 'Connect'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {github.connected && (
+        <div className="settings-group">
+          <label className="settings-label">Sidebar</label>
+          <label className="visibility-row" style={{ cursor: 'pointer' }}>
+            <span className="visibility-row-label">Show GitHub in sidebar</span>
+            <label className="toggle-switch">
+              <input
+                type="checkbox"
+                checked={github.show}
+                onChange={(e) => void update('integrations', { github: { ...github, show: e.target.checked } })}
+              />
+              <span className="toggle-track"><span className="toggle-knob" /></span>
+            </label>
+          </label>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/useGitHub.ts
+++ b/web/src/hooks/useGitHub.ts
@@ -1,0 +1,52 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { apiGet } from '../lib/api';
+import { useSettings } from '../contexts/SettingsContext';
+import { GITHUB_POLL_INTERVAL_MS } from '../lib/timing-constants';
+
+export interface GitHubSummary {
+  notificationCount: number;
+  reviewRequested: number;
+  assignedIssues: number;
+  username: string;
+}
+
+export function useGitHub() {
+  const { settings } = useSettings();
+  const githubConnected = settings.integrations.github.connected;
+  const [summary, setSummary] = useState<GitHubSummary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchSummary = useCallback(async () => {
+    try {
+      const data = await apiGet<GitHubSummary>('/github/summary');
+      setSummary(data);
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Failed to load GitHub';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!githubConnected) {
+      setSummary(null);
+      setError(null);
+      if (pollRef.current) clearInterval(pollRef.current);
+      return;
+    }
+
+    setLoading(true);
+    void fetchSummary();
+    pollRef.current = setInterval(() => { void fetchSummary(); }, GITHUB_POLL_INTERVAL_MS);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [githubConnected, fetchSummary]);
+
+  return { summary, loading, error, githubConnected };
+}

--- a/web/src/hooks/useIntegrationSync.ts
+++ b/web/src/hooks/useIntegrationSync.ts
@@ -6,6 +6,7 @@ import { apiGet } from '../lib/api';
 interface IntegrationsResponse {
   google: { connected: boolean; scopes: string[] };
   spotify: { connected: boolean };
+  github: { connected: boolean };
 }
 
 /**
@@ -28,6 +29,7 @@ export function useIntegrationSync() {
           calendar: { ...settings.integrations.calendar, connected: false },
           spotify: { ...settings.integrations.spotify, connected: false },
           gmail: { ...settings.integrations.gmail, connected: false },
+          github: { ...settings.integrations.github, connected: false },
         },
       });
       return;
@@ -36,7 +38,7 @@ export function useIntegrationSync() {
     let cancelled = false;
 
     apiGet<IntegrationsResponse>('/integrations')
-      .then(({ google, spotify }) => {
+      .then(({ google, spotify, github }) => {
         if (cancelled) return;
         const hasGmailScope = google.scopes.some((s) => s.includes('gmail'));
         void updateMultiple({
@@ -45,6 +47,7 @@ export function useIntegrationSync() {
             calendar: { ...settings.integrations.calendar, connected: google.connected },
             spotify: { ...settings.integrations.spotify, connected: spotify.connected },
             gmail: { ...settings.integrations.gmail, connected: google.connected && hasGmailScope },
+            github: { ...settings.integrations.github, connected: github.connected },
           },
         });
       })

--- a/web/src/lib/migrateSettings.ts
+++ b/web/src/lib/migrateSettings.ts
@@ -86,6 +86,7 @@ export function migrateFlatToSectioned(legacy: LegacySettings): Settings {
       },
       finance: { ...d.integrations.finance },
       gmail: { ...d.integrations.gmail },
+      github: { ...d.integrations.github },
     },
   };
 }

--- a/web/src/lib/timing-constants.ts
+++ b/web/src/lib/timing-constants.ts
@@ -30,3 +30,6 @@ export const CALENDAR_FETCH_DEBOUNCE_MS = 500;
 
 // Gmail poll interval (45s matches server-side cache TTL)
 export const GMAIL_POLL_INTERVAL_MS = 45_000;
+
+// GitHub poll interval (60s matches server-side cache TTL)
+export const GITHUB_POLL_INTERVAL_MS = 60_000;

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -4810,3 +4810,81 @@ body.focus-exiting .sidebar-container {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* ── GitHub Widget ─────────────────────────────────────────────────────────── */
+
+.github-widget {
+  padding: 12px 0 4px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  margin-top: 8px;
+}
+.github-widget-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding: 0 2px;
+}
+.github-widget-title {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.75);
+  flex: 1;
+}
+.github-badge {
+  background: rgba(248, 113, 113, 0.85);
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 10px;
+  min-width: 18px;
+  text-align: center;
+}
+.github-widget-empty {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.35);
+  text-align: center;
+  padding: 8px 0 12px;
+}
+.github-widget-error {
+  font-size: 0.72rem;
+  color: rgba(248, 113, 113, 0.8);
+  padding: 4px 2px 8px;
+}
+.github-stat-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.github-stat-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: rgba(255, 255, 255, 0.7);
+  transition: background 0.15s;
+}
+.github-stat-row:hover {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.9);
+}
+.github-stat-icon {
+  display: flex;
+  align-items: center;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+.github-stat-label {
+  font-size: 0.75rem;
+  flex: 1;
+}
+.github-stat-count {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.55);
+  min-width: 16px;
+  text-align: right;
+}

--- a/web/src/types/settings.ts
+++ b/web/src/types/settings.ts
@@ -84,11 +84,19 @@ export interface GmailIntegration {
   show: boolean;
 }
 
+export interface GitHubIntegration {
+  /** Derived from PAT existence - excluded from backend sync. */
+  connected: boolean;
+  /** Whether to show the GitHub widget in the sidebar. */
+  show: boolean;
+}
+
 export interface IntegrationsSettings {
   calendar: CalendarIntegration;
   spotify: SpotifyIntegration;
   finance: FinanceIntegration;
   gmail: GmailIntegration;
+  github: GitHubIntegration;
 }
 
 // ─── Top-level Settings ───────────────────────────────────────────────────────
@@ -205,6 +213,7 @@ export const defaultSettings: Settings = {
       connected: false,
     },
     gmail: { connected: false, show: true },
+    github: { connected: false, show: true },
   },
 };
 


### PR DESCRIPTION
## What
- Add GitHub PR & issue widget (#192) — PAT-based integration with live notification, review request, and assigned issue counts in the right sidebar
- Fix 8 Phase 9 critical security issues: pin flyctl-actions, CI timeouts, fly.toml machine cap, move hardcoded CI secrets to GitHub Secrets, validate sender.id in background message handler, hash email tokens before DB storage
- Document content script broad match scope as intentional (#203)

## Why
Phase 8 (Integrations) was missing the GitHub widget as the only unfinished item. Phase 9 contained critical supply chain, DoS surface, and token security gaps that needed to land before production. Email tokens were stored as plaintext — the same bcrypt+sha256 dual-hash pattern used by refresh_sessions should have applied here from the start.

## How
GitHub integration reuses the existing `oauth_accounts` table with `provider='github'` — no OAuth dance required since PATs are user-supplied. The backend validates the PAT via `GET /user` before encrypting and storing it. Email token hashing mirrors the refresh_sessions pattern exactly: `tokenLookup` (sha256 hex) for O(1) DB lookup, `tokenHash` (bcrypt) for constant-time verification. The `sender.id` fix corrects a TypeScript type error where `sender.extensionId` does not exist on `MessageSender`.

## Test plan
- [ ] Enter a valid GitHub Classic PAT in Settings → Apps → GitHub → Connect; widget appears in sidebar with live counts
- [ ] Disconnect GitHub; widget disappears and `integrations.github.connected` clears
- [ ] Request a password reset; check `email_tokens` table — `token_lookup` and `token_hash` are populated, raw `token` column holds bcrypt hash not plaintext
- [ ] Verify CI job timeouts appear in Actions run log (`timeout-minutes: 15` / `10`)
- [ ] Confirm CI passes after adding GitHub Secrets (`TEST_JWT_SECRET`, `TEST_REFRESH_SECRET`, `TEST_ENC_KEY_BASE64`) to repo Settings → Secrets
- [ ] `flyctl scale show -a windom-api` reflects `max_machines_running = 3` after next deploy

Closes #192, #196, #197, #198, #200, #201, #202, #203

Generated by [Claude-Bot] of [@Yehuda Briskman]