### PR TITLE
Improve GlassSelect keyboard accessibility

### DIFF
--- a/web/src/components/ui/GlassSelect.tsx
+++ b/web/src/components/ui/GlassSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId, type KeyboardEvent } from 'react';
 import { ChevronDown } from 'lucide-react';
 
 interface Option {
@@ -15,9 +15,18 @@ interface GlassSelectProps {
 
 export function GlassSelect({ value, onChange, options, className = '' }: GlassSelectProps) {
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const id = useId();
 
   const selected = options.find((o) => o.value === value);
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((o) => o.value === value),
+  );
+  const listboxId = `${id}-glass-select-listbox`;
+  const activeOptionId = options[activeIndex] ? `${listboxId}-option-${activeIndex}` : undefined;
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -27,27 +36,101 @@ export function GlassSelect({ value, onChange, options, className = '' }: GlassS
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
+  useEffect(() => {
+    if (open) setActiveIndex(selectedIndex);
+  }, [open, selectedIndex]);
+
+  const closeAndFocusTrigger = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const selectOption = (index: number) => {
+    const option = options[index];
+    if (!option) return;
+
+    onChange(option.value);
+    closeAndFocusTrigger();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        if (!open) {
+          setOpen(true);
+          setActiveIndex(selectedIndex);
+          return;
+        }
+        setActiveIndex((index) => Math.min(index + 1, options.length - 1));
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (!open) {
+          setOpen(true);
+          setActiveIndex(selectedIndex);
+          return;
+        }
+        setActiveIndex((index) => Math.max(index - 1, 0));
+        break;
+      case 'Home':
+        e.preventDefault();
+        if (!open) setOpen(true);
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        if (!open) setOpen(true);
+        setActiveIndex(Math.max(options.length - 1, 0));
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        if (!open) {
+          setOpen(true);
+          setActiveIndex(selectedIndex);
+          return;
+        }
+        selectOption(activeIndex);
+        break;
+      case 'Escape':
+        if (open) {
+          e.preventDefault();
+          closeAndFocusTrigger();
+        }
+        break;
+    }
+  };
+
   return (
     <div ref={ref} className={`glass-select-wrapper ${className}`}>
       <button
+        ref={triggerRef}
         type="button"
         className="glass-select-trigger"
         onClick={() => setOpen((o) => !o)}
+        onKeyDown={handleKeyDown}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-activedescendant={open ? activeOptionId : undefined}
       >
         <span>{selected?.label ?? value}</span>
         <ChevronDown size={15} className={`glass-select-chevron ${open ? 'open' : ''}`} />
       </button>
 
       {open && (
-        <ul className="glass-select-dropdown" role="listbox">
-          {options.map((opt) => (
+        <ul id={listboxId} className="glass-select-dropdown" role="listbox">
+          {options.map((opt, index) => (
             <li
+              id={`${listboxId}-option-${index}`}
               key={opt.value}
               role="option"
               aria-selected={opt.value === value}
-              className={`glass-select-option ${opt.value === value ? 'active' : ''}`}
+              className={`glass-select-option ${opt.value === value ? 'active' : ''} ${
+                index === activeIndex ? 'keyboard-active' : ''
+              }`}
+              onMouseEnter={() => setActiveIndex(index)}
               onMouseDown={(e) => {
                 e.preventDefault();
                 onChange(opt.value);

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -196,7 +196,8 @@ select option {
   transition: background 0.15s ease, color 0.15s ease;
 }
 
-.glass-select-option:hover {
+.glass-select-option:hover,
+.glass-select-option.keyboard-active {
   background: rgba(255, 255, 255, 0.1);
   color: white;
 }
@@ -205,6 +206,10 @@ select option {
   background: rgba(255, 255, 255, 0.14);
   color: white;
   font-weight: 500;
+}
+
+.glass-select-option.active.keyboard-active {
+  background: rgba(255, 255, 255, 0.18);
 }
 
 input[type="file"]::file-selector-button {


### PR DESCRIPTION
## Summary
- Add keyboard handling to `GlassSelect` for ArrowUp/ArrowDown, Home/End, Enter/Space, and Escape.
- Track the active option while the dropdown is open and expose it with `aria-activedescendant`.
- Add a visible keyboard-active option state that follows arrow-key navigation.

Closes #243.

## Validation
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npm test`
