### PR TITLE
Fix GlassSelect keyboard navigation

### DIFF
--- a/web/src/components/ui/GlassSelect.test.tsx
+++ b/web/src/components/ui/GlassSelect.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { GlassSelect } from './GlassSelect';
+
+const options = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+  { value: 'three', label: 'Three' },
+];
+
+describe('GlassSelect keyboard navigation', () => {
+  it('opens, navigates, selects, and closes with the keyboard', () => {
+    const onChange = vi.fn();
+    render(<GlassSelect value="one" onChange={onChange} options={options} />);
+
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    const firstOption = screen.getByRole('option', { name: 'One' });
+    expect(document.activeElement).toBe(firstOption);
+
+    fireEvent.keyDown(firstOption, { key: 'ArrowDown' });
+    const secondOption = screen.getByRole('option', { name: 'Two' });
+    expect(document.activeElement).toBe(secondOption);
+
+    fireEvent.keyDown(secondOption, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith('two');
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('closes with Escape and returns focus to the trigger', () => {
+    render(<GlassSelect value="one" onChange={vi.fn()} options={options} />);
+
+    const trigger = screen.getByRole('button');
+    fireEvent.keyDown(trigger, { key: 'End' });
+
+    const lastOption = screen.getByRole('option', { name: 'Three' });
+    expect(document.activeElement).toBe(lastOption);
+
+    fireEvent.keyDown(lastOption, { key: 'Escape' });
+
+    expect(screen.queryByRole('listbox')).toBeNull();
+    expect(document.activeElement).toBe(trigger);
+  });
+});

--- a/web/src/components/ui/GlassSelect.tsx
+++ b/web/src/components/ui/GlassSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId, type KeyboardEvent } from 'react';
 import { ChevronDown } from 'lucide-react';
 
 interface Option {
@@ -15,9 +15,36 @@ interface GlassSelectProps {
 
 export function GlassSelect({ value, onChange, options, className = '' }: GlassSelectProps) {
   const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<Array<HTMLLIElement | null>>([]);
+  const listboxId = useId();
 
   const selected = options.find((o) => o.value === value);
+  const selectedIndex = Math.max(
+    0,
+    options.findIndex((o) => o.value === value),
+  );
+
+  const openAt = (index: number) => {
+    setActiveIndex(index);
+    setOpen(true);
+  };
+
+  const closeAndFocusTrigger = () => {
+    setOpen(false);
+    triggerRef.current?.focus();
+  };
+
+  const selectOption = (option: Option) => {
+    onChange(option.value);
+    closeAndFocusTrigger();
+  };
+
+  const moveActiveOption = (nextIndex: number) => {
+    setActiveIndex((nextIndex + options.length) % options.length);
+  };
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -27,31 +54,111 @@ export function GlassSelect({ value, onChange, options, className = '' }: GlassS
     return () => document.removeEventListener('mousedown', handler);
   }, []);
 
+  useEffect(() => {
+    if (!open) return;
+    optionRefs.current[activeIndex]?.focus();
+  }, [activeIndex, open]);
+
+  const handleTriggerKeyDown = (e: KeyboardEvent<HTMLButtonElement>) => {
+    if (options.length === 0) return;
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        openAt(open ? activeIndex + 1 : selectedIndex);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        openAt(open ? activeIndex - 1 : selectedIndex);
+        break;
+      case 'Home':
+        e.preventDefault();
+        openAt(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        openAt(options.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        openAt(selectedIndex);
+        break;
+      case 'Escape':
+        if (open) {
+          e.preventDefault();
+          closeAndFocusTrigger();
+        }
+        break;
+    }
+  };
+
+  const handleOptionKeyDown = (e: KeyboardEvent<HTMLLIElement>, opt: Option) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        moveActiveOption(activeIndex + 1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        moveActiveOption(activeIndex - 1);
+        break;
+      case 'Home':
+        e.preventDefault();
+        setActiveIndex(0);
+        break;
+      case 'End':
+        e.preventDefault();
+        setActiveIndex(options.length - 1);
+        break;
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        selectOption(opt);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        closeAndFocusTrigger();
+        break;
+    }
+  };
+
   return (
     <div ref={ref} className={`glass-select-wrapper ${className}`}>
       <button
+        ref={triggerRef}
         type="button"
         className="glass-select-trigger"
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => {
+          setActiveIndex(selectedIndex);
+          setOpen((isOpen) => !isOpen);
+        }}
+        onKeyDown={handleTriggerKeyDown}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={listboxId}
       >
         <span>{selected?.label ?? value}</span>
         <ChevronDown size={15} className={`glass-select-chevron ${open ? 'open' : ''}`} />
       </button>
 
       {open && (
-        <ul className="glass-select-dropdown" role="listbox">
-          {options.map((opt) => (
+        <ul id={listboxId} className="glass-select-dropdown" role="listbox">
+          {options.map((opt, index) => (
             <li
+              ref={(node) => {
+                optionRefs.current[index] = node;
+              }}
               key={opt.value}
               role="option"
               aria-selected={opt.value === value}
+              tabIndex={index === activeIndex ? 0 : -1}
               className={`glass-select-option ${opt.value === value ? 'active' : ''}`}
+              onKeyDown={(e) => handleOptionKeyDown(e, opt)}
+              onMouseEnter={() => setActiveIndex(index)}
               onMouseDown={(e) => {
                 e.preventDefault();
-                onChange(opt.value);
-                setOpen(false);
+                selectOption(opt);
               }}
             >
               {opt.label}


### PR DESCRIPTION
## Summary
- add keyboard handling to `GlassSelect` for ArrowUp/ArrowDown, Home/End, Enter/Space, and Escape
- keep focus inside the open listbox while navigating options
- return focus to the trigger after selecting an option or closing with Escape
- add regression tests for keyboard selection and Escape behavior

Fixes #243.

## Validation
- `npm run lint` (passes with existing warnings)
- `npm test`
- `npm run build`
- `npx prettier --check src/components/ui/GlassSelect.tsx src/components/ui/GlassSelect.test.tsx`
