### PR TITLE
Fix keyboard access for clickable widgets

### DIFF
--- a/web/src/components/focus/FocusInput.tsx
+++ b/web/src/components/focus/FocusInput.tsx
@@ -69,7 +69,8 @@ export function FocusInput() {
   // Has text: show as clickable display (click toggles completion, double-click to edit)
   return (
     <div className="focus-container">
-      <div
+      <button
+        type="button"
         onClick={toggleCompleted}
         onDoubleClick={startEditing}
         className="focus-display"
@@ -78,9 +79,10 @@ export function FocusInput() {
           opacity: completed ? 0.6 : 1,
         }}
         title="Click to toggle completion, double-click to edit"
+        aria-pressed={completed}
       >
         {text}
-      </div>
+      </button>
     </div>
   );
 }

--- a/web/src/components/quotes/QuoteDisplay.tsx
+++ b/web/src/components/quotes/QuoteDisplay.tsx
@@ -6,10 +6,12 @@ export function QuoteDisplay() {
   if (!enabled) return null;
 
   return (
-    <div
+    <button
+      type="button"
       className="quote-container"
       onClick={refresh}
       title="Click for new quote"
+      aria-label="Show a new quote"
     >
       <p
         className="quote-text text-shadow-sm"
@@ -23,6 +25,6 @@ export function QuoteDisplay() {
       >
         {quote ? `\u2014 ${quote.author}` : ''}
       </p>
-    </div>
+    </button>
   );
 }

--- a/web/src/components/search/SearchOverlay.tsx
+++ b/web/src/components/search/SearchOverlay.tsx
@@ -447,8 +447,9 @@ export function SearchOverlay() {
             <button
               className="search-engine-pill"
               onClick={() => setEnginePickerOpen(p => !p)}
-              tabIndex={-1}
               type="button"
+              aria-expanded={enginePickerOpen}
+              aria-label="Choose search engine"
             >
               {ENGINE_LABELS[settings.general.searchEngine] ?? 'Google'}
               <ChevronDown size={11} strokeWidth={2} />

--- a/web/src/components/settings/PhotoGrid.tsx
+++ b/web/src/components/settings/PhotoGrid.tsx
@@ -16,7 +16,21 @@ export function PhotoGrid({ photos, onLike, onSelect, onDelete }: PhotoGridProps
   return (
     <div className="photo-grid">
       {photos.map((photo) => (
-        <div key={photo.id} className="photo-thumb" onClick={() => onSelect(photo)}>
+        <div
+          key={photo.id}
+          className="photo-thumb"
+          onClick={() => onSelect(photo)}
+          onKeyDown={(e) => {
+            if (e.currentTarget !== e.target) return;
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onSelect(photo);
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label={`Select photo by ${photo.photographer}`}
+        >
           <img src={photo.thumbUrl} alt={`Photo by ${photo.photographer}`} loading="lazy" />
           <div className="photo-thumb-overlay">
             <span className="photo-thumb-credit">{photo.photographer}</span>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -909,6 +909,11 @@ input[type="file"]::file-selector-button:hover {
 }
 
 .focus-display {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  width: 100%;
   font-size: 28px;
   text-align: center;
   cursor: pointer;
@@ -1569,6 +1574,13 @@ input[type="file"]::file-selector-button:hover {
    Quotes
    ============================================================ */
 .quote-container {
+  display: block;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: center;
   padding: 24px;
   border-radius: 16px;
   opacity: 0.9;


### PR DESCRIPTION
## Summary
- Convert focus display and quote refresh controls from clickable divs to buttons
- Make photo thumbnails keyboard-activatable while avoiding nested button markup
- Restore keyboard access and state labelling for the search engine picker button

Closes #239

## Checks
- npm run lint (passes with existing warnings)
- npm run build